### PR TITLE
DRUP-663: adds usability ORCID form edits

### DIFF
--- a/www/sites/all/modules/contrib/orcid_integration/includes/orcid_integration.pages.inc
+++ b/www/sites/all/modules/contrib/orcid_integration/includes/orcid_integration.pages.inc
@@ -10,11 +10,12 @@
  */
 function orcid_integration_view_page($account) {
   if (empty($account->field_orcid_id)) {
-    drupal_set_message(t('Your orcid ID is not yet set up'), 'warning');
+    // drupal_set_message(t('Your orcid ID is not yet set up'), 'warning');
     return drupal_get_form('orcid_integration_map_account', $account);
   }
   else {
-    return '<div class="orcid-account-id">' . $account->field_orcid_id[LANGUAGE_NONE][0]['value'] . '</div>';
+    // display the ORCID with an unlink button
+    return drupal_get_form('orcid_integration_account_unlink', $account);
   }
   return '';
 }
@@ -68,7 +69,7 @@ function orcid_integration_map_account($form, &$form_state, $account) {
 
   $form['mapping'] = array(
     '#type' => 'fieldset',
-    '#title' => t('Possible matches'),
+    '#title' => t('Search for Existing Account by Email'),
     '#collapsed' => FALSE,
   );
   $form['mapping']['search_ajax'] = array(
@@ -155,7 +156,7 @@ function orcid_integration_map_account($form, &$form_state, $account) {
       '#value' => t('Create'),
     );
   }
-  
+
   return $form;
 }
 
@@ -208,5 +209,42 @@ function orcid_integration_map_account_submit($form, &$form_state) {
   $account = user_load($values['account']->uid);
   $account->field_orcid_id[LANGUAGE_NONE][0]['value'] = $orcid_id;
   user_save($account);
-  drupal_set_message(t('Account now mapped to @orcid_id', array('@orcid_id' => $orcid_id)));
+  drupal_set_message(t('Account successfully linked to profile.'));
+  $form_state['redirect'] = 'user/' . $account->uid;
+}
+
+/**
+ * Displays the currently linked ORCID account with an unlink button
+ */
+function orcid_integration_account_unlink($form, &$form_state, $account) {
+  $form['orcid'] = array(
+    '#type' => 'item',
+    '#title' => t('Your linked ORCID Account'),
+    '#markup' => l(
+      variable_get('orcid_integration_main_url') . $account->field_orcid_id[LANGUAGE_NONE][0]['value'],
+      variable_get('orcid_integration_main_url') . $account->field_orcid_id[LANGUAGE_NONE][0]['value'],
+      $options = array(
+        'attributes' => array(
+          'target' => '_blank',
+        ),
+      )
+    ),
+  );
+  $form['unlink'] = array(
+    '#type' => 'submit',
+    '#value' => t('Unlink ORCID Account'),
+  );
+  return $form;
+}
+
+/**
+ * Summit handler for orcid_integration_account_unlink
+ */
+function orcid_integration_account_unlink_submit($form, &$form_state) {
+  // unlink ORCID account by removing (unsetting) the value of $account->field_orcid_id
+  $account = user_load($form_state['build_info']['args'][0]->uid);
+  unset($account->field_orcid_id);
+  $account->field_orcid_id = array();
+  user_save($account);
+  drupal_set_message(t('ORCID Account successfully unlinked.'));
 }

--- a/www/sites/all/modules/contrib/orcid_integration/orcid_integration.module
+++ b/www/sites/all/modules/contrib/orcid_integration/orcid_integration.module
@@ -20,7 +20,7 @@ function orcid_integration_menu() {
     'access arguments' => array('administer site configuration'),
     'file' => 'includes/orcid_integration.admin.inc',
   );
-  
+
   $items['user/%user/orcid'] = array(
     'title' => 'ORCID',
     'page callback' => 'orcid_integration_view_page',
@@ -105,7 +105,7 @@ function orcid_integration_search_by_orcid_id($id) {
 }
 
 /**
- * Generates publich search url (and parameters).
+ * Generates public search url (and parameters).
  */
 function orcid_integration_generate_public_search_url($api_url = NULL) {
   if (empty($api_url)) {

--- a/www/sites/all/modules/custom/orcid_integration_extras/orcid_integration_extras.info
+++ b/www/sites/all/modules/custom/orcid_integration_extras/orcid_integration_extras.info
@@ -1,0 +1,6 @@
+name = ORCID Integration - extras
+description = Extra tweaks to the Orcid integration that are specific to UCLA Library and do not belong in the main orcid_integration module
+package = ORCID
+core = 7.x
+version = 7.x-1.0
+dependencies[] = orcid_integration

--- a/www/sites/all/modules/custom/orcid_integration_extras/orcid_integration_extras.module
+++ b/www/sites/all/modules/custom/orcid_integration_extras/orcid_integration_extras.module
@@ -1,0 +1,11 @@
+<?php
+
+/**
+ * Implementation of hook_form_FORM_ID_alter().
+ * via:
+ * Implementation of hook_form_user_profile_form_alter().
+ */
+ function orcid_integration_extras_form_user_profile_form_alter(&$form, &$form_state, $form_id) {
+ 	// hide the ORCID field on the user edit form (aka user_profile_form) via: DRUP-668
+  $form['field_orcid_id']['#access'] = FALSE;
+}

--- a/www/sites/all/modules/custom/orcid_redirect/orcid_redirect.info
+++ b/www/sites/all/modules/custom/orcid_redirect/orcid_redirect.info
@@ -1,7 +1,6 @@
 name = "ORCID Redirect"
 description = "Provides user-specific redirect to ORCID page for authenticated users ."
-package = "Other"
+package = ORCID
 core = "7.x"
-version = "7.x-1.0"
+version = 7.x-1.1
 dependencies[] = orcid_integration
-

--- a/www/sites/all/themes/uclalib_omega/css/uclalib-omega.no-query.css
+++ b/www/sites/all/themes/uclalib_omega/css/uclalib-omega.no-query.css
@@ -921,6 +921,10 @@ a[href="#main-content"] {
   padding: 0 !important;
 }
 
+.orcid-integration-map-account > div:not(.fieldset-wrapper) > fieldset {
+  margin-top: 2em;
+}
+
 /**
  * Override jQuery UI widget default font sizes.
  */
@@ -1214,7 +1218,7 @@ a.more-link,
   text-indent: -119988px;
   overflow: hidden;
   text-align: left;
-  background-image: url('../images/logo-colophon.png?1399407339');
+  background-image: url('../images/logo-colophon.png?1421365312');
   background-repeat: no-repeat;
   background-position: 50% 50%;
   width: 150px;

--- a/www/sites/all/themes/uclalib_omega/css/uclalib-omega.styles.css
+++ b/www/sites/all/themes/uclalib_omega/css/uclalib-omega.styles.css
@@ -921,6 +921,10 @@ a[href="#main-content"] {
   padding: 0 !important;
 }
 
+.orcid-integration-map-account > div:not(.fieldset-wrapper) > fieldset {
+  margin-top: 2em;
+}
+
 /**
  * Override jQuery UI widget default font sizes.
  */
@@ -1214,7 +1218,7 @@ a.more-link,
   text-indent: -119988px;
   overflow: hidden;
   text-align: left;
-  background-image: url('../images/logo-colophon.png?1399407339');
+  background-image: url('../images/logo-colophon.png?1421365312');
   background-repeat: no-repeat;
   background-position: 50% 50%;
   width: 150px;

--- a/www/sites/all/themes/uclalib_omega/sass/components/_form_orcid.scss
+++ b/www/sites/all/themes/uclalib_omega/sass/components/_form_orcid.scss
@@ -1,0 +1,3 @@
+.orcid-integration-map-account > div:not(.fieldset-wrapper) > fieldset {
+	margin-top:	2em;
+}


### PR DESCRIPTION
DRUP-663: improves usabiity by changing "Posible Matches" to "Search for Existing Account by Email" via DRUP-665

DRUP-663: Surpresses "orchid ID is not set up" message, DRUP-666: fixes account mapped copy, DRUP-667: changes confrmation screen to go to user view

DRUP-663: hides the ORCID field on the user edit form (aka user_profile_form) via: DRUP-668

adds version and package group to orcid_integration module

DRUP-669 adds unlink ORCID button and functionality