### PR TITLE
OP-725: Extended allowable dates to June 30 2016

### DIFF
--- a/www/sites/all/modules/custom/default_opening_hours/default_opening_hours.module
+++ b/www/sites/all/modules/custom/default_opening_hours/default_opening_hours.module
@@ -123,7 +123,7 @@ function _default_opening_hours_create_defaults($node) {
 
   $date_prefix = date_create()->format('Y-m');
   // OP-77: Until we define/implement a UI, enter the final date of the session/quarter
-  $to_date = date_create('2015-06-30')->format('Y-m-d');
+  $to_date = date_create('2016-06-30')->format('Y-m-d');
 
   $record = array(
     'nid' => $node->nid,


### PR DESCRIPTION
@z3cka You asked about this - at present, just a hard-coded date in the default_opening_hours custom module from Bluespark.  Go ahead and merge, please.

I considered doing an administrative interface for this, but since we're extending the current allowable dates to 2016 and our new hours project should be done long before that... not worth the effort to do an admin module for the current system.
