### PR TITLE
WS-409: #ready Changes front page Databases tab search to use …

### DIFF
--- a/www/sites/all/modules/custom/ucla_search/includes/ucla_search_handlers.inc
+++ b/www/sites/all/modules/custom/ucla_search/includes/ucla_search_handlers.inc
@@ -76,7 +76,7 @@ function serial_solutions_360($search_info) {
 }
 
 function ucla_search_database($search_info) {
-  $target_url = 'http://unitproj.library.ucla.edu/search/databases-title-result.cfm';
+  $target_url = 'http://guides.library.ucla.edu/az.php';
   // Replace space with plus, but do NOT url encode the terms
   $target_url .= '?keyword=' . str_replace(' ', '+', $search_info['search_terms']);
   if ($search_info['search_type']) {

--- a/www/sites/all/modules/custom/ucla_search/ucla_search.info
+++ b/www/sites/all/modules/custom/ucla_search/ucla_search.info
@@ -2,5 +2,5 @@ name = UCLA Search
 description = Routines for building searches to various targets, and for logging searches to database.
 package = UCLA Search modules
 core = 7.x
-version = "7.x-1.2"
+version = "7.x-1.3"
 dependencies[] = views_data_export

--- a/www/sites/all/modules/custom/ucla_tab_search/ucla_tab_search.info
+++ b/www/sites/all/modules/custom/ucla_tab_search/ucla_tab_search.info
@@ -1,5 +1,5 @@
 name = UCLA Tab Search
 description = Custom tab forms for searching on the UCLA Library homepage.
 core = 7.x
-version = "7.x-1.2"
+version = "7.x-1.3"
 dependencies[] = ucla_search

--- a/www/sites/all/modules/custom/ucla_tab_search/ucla_tab_search.module
+++ b/www/sites/all/modules/custom/ucla_tab_search/ucla_tab_search.module
@@ -59,7 +59,7 @@ function ucla_tab_search_tabs_form($form, &$form_state) {
     '#type' => 'textfield',
   );
   // Overrides to include default and extra callback.
-  $form['#submit'] = array('ucla_tab_search_tabs_form_submit', 'ucla_search_custom_form_submit');
+  $form['#submit'] = array('ucla_tab_search_tabs_form_submit');
 
   ////////////////////////////////////////////////////////////////////////////////
   // Books & More tab.
@@ -240,14 +240,6 @@ can be changed via a pulldown search limit on the results screen. Many records c
     '#states' => array(
       'visible' => array(':input[name="databases[databases_catalog]"]' => array('value' => 'TWO')),
     ),
-  );
-  $form['databases']['method'] = array(
-    '#type' => 'radios',
-    '#options' => array(
-        'within' => t('Contains'),
-        'starts' => t('Starts with'),
-    ),
-    '#default_value' => 'within',
   );
 
   $form['databases']['databases_search'] = $search_button;
@@ -538,31 +530,14 @@ function ucla_tab_search_tabs_form_submit($form, &$form_state) {
 	  } else {
 	    $search_year = 'date';
 	  }
-	  switch ( $form_state['values']['databases']['method'] ) {
-//	  $maps[$form_state['values']['databases']['method']] ) {
-	    case 'within':
-	      // Put form info into array expected by search logger / handlers
-	      $search_info = array (
+      $search_info = array (
 	      'search_target' => 'database',
 	      'search_type' => 'contains',
 	      'search_terms' => $form_state['values']['databases']['text_query'],
 	      'search_date' => $search_date,
 	      'browser_ip' => $browser_ip,
-              'search_form' => 'DB',
-	      );
-	    break;
-	    case 'starts':
-	      // Put form info into array expected by search logger / handlers
-	      $search_info = array (
-	      'search_target' => 'database',
-	      'search_type' => 'starts',
-	      'search_terms' => $form_state['values']['databases']['text_query'],
-	      'search_date' => $search_date,
-	      'browser_ip' => $browser_ip,
-              'search_form' => 'DB',
-	      );
-	      break;
-	  }
+        'search_form' => 'DB',
+      );
         break;
 
         case 'edit-journals':


### PR DESCRIPTION
… http://guides.library.ucla.edu/az.php

Notes: * removes "contains" and "starts with" options and associated options
       * removes call to ucla_search_custom_form_submit callback that does not exists (that I could find)

WS-409: removes commented code that should have just been removed

@akohler ready for deployment to test (we really have got to automate this so I don't have to bug you so much)