### PR TITLE
DRUP-675: #ready makes ORCID api calls with variables from configuration

### DIFF
--- a/www/sites/all/modules/contrib/orcid_integration/includes/orcid_integration.pages.inc
+++ b/www/sites/all/modules/contrib/orcid_integration/includes/orcid_integration.pages.inc
@@ -222,7 +222,6 @@ function orcid_integration_account_unlink($form, &$form_state, $account) {
     '#title' => t('Your linked ORCID Account'),
     '#markup' => l(
       variable_get('orcid_integration_main_url') . $account->field_orcid_id[LANGUAGE_NONE][0]['value'],
-      variable_get('orcid_integration_main_url') . $account->field_orcid_id[LANGUAGE_NONE][0]['value'],
       $options = array(
         'attributes' => array(
           'target' => '_blank',
@@ -245,6 +244,8 @@ function orcid_integration_account_unlink_submit($form, &$form_state) {
   $account = user_load($form_state['build_info']['args'][0]->uid);
   unset($account->field_orcid_id);
   $account->field_orcid_id = array();
+  unset($account->data['orcid_response']);
+  unset($account->data['orcid_code']);
   user_save($account);
   drupal_set_message(t('ORCID Account successfully unlinked.'));
 }

--- a/www/sites/all/modules/contrib/orcid_integration/orcid_integration.info
+++ b/www/sites/all/modules/contrib/orcid_integration/orcid_integration.info
@@ -1,5 +1,5 @@
 name = "ORCID Integration"
 description = "Integration with the ORCID system"
 core = "7.x"
-version = "7.x-1.0"
+version = "7.x-1.1"
 package = "Other"

--- a/www/sites/all/modules/contrib/orcid_integration/orcid_oauth/orcid-oauth-connect.tpl.php
+++ b/www/sites/all/modules/contrib/orcid_integration/orcid_oauth/orcid-oauth-connect.tpl.php
@@ -1,0 +1,21 @@
+<button id="connect-orcid-button" onclick="openORCID()">
+  <img id="orcid-id-logo" src="http://orcid.org/sites/default/files/images/orcid_24x24.png" width='24' height='24' alt="ORCID logo"/>
+  Create or connect your ORCID iD
+</button>
+
+<script type="text/javascript">
+  var oauthWindow;
+  jQuery('button').click(function(e) {
+  	e.preventDefault();
+  });
+  function openORCID() {
+    var oauthWindow = window.open(""+
+    	"<?php print $orcid['main_url']; ?>oauth/authorize?client_id=<?php print $orcid['client_id']; ?>"+
+    	"&response_type=code"+
+    	"&scope=/authenticate"+
+    	"&redirect_uri=<?php print $orcid['redirect_url']; ?>user/<?php print $account->uid; ?>/orcid_thankyou",
+    	"_blank",
+    	"toolbar=no, scrollbars=yes, width=500, height=600, top=500, left=500"
+    );
+  }
+</script>

--- a/www/sites/all/modules/contrib/orcid_integration/orcid_oauth/orcid-oauth-connected.tpl.php
+++ b/www/sites/all/modules/contrib/orcid_integration/orcid_oauth/orcid-oauth-connected.tpl.php
@@ -1,0 +1,2 @@
+ORCID connected! This user's ID is: <?php print $account->data['orcid_response']['orcid']; ?>
+<p>// TODO: add an unlink button here.</p>

--- a/www/sites/all/modules/contrib/orcid_integration/orcid_oauth/orcid-oauth-thankyou.tpl.php
+++ b/www/sites/all/modules/contrib/orcid_integration/orcid_oauth/orcid-oauth-thankyou.tpl.php
@@ -1,0 +1,16 @@
+<p>Thank you for connecting your ORCID account.</p>
+<button id="thankyou-close">Close this window</button>
+<script type="text/javascript">
+	(function ($) {
+    $(document).ready(function () {
+			$.ajax({
+				url:"/user/<?php print $account->uid; ?>/orcid_oauth",
+				async:true
+			});
+      $('#thankyou-close').click(function () {
+        window.opener.location.reload(true);
+        window.close();
+      });
+    });
+  })(jQuery);
+</script>

--- a/www/sites/all/modules/contrib/orcid_integration/orcid_oauth/orcid_oauth.info
+++ b/www/sites/all/modules/contrib/orcid_integration/orcid_oauth/orcid_oauth.info
@@ -1,0 +1,9 @@
+name = ORCID - OAuth
+description = ORCID integration via OAuth
+package = ORCID
+core = 7.x
+version = 7.x-2.0
+dependencies[] = orcid_integration
+dependencies[] = wsclient
+dependencies[] = wsclient_rest
+project = orcid_oauth

--- a/www/sites/all/modules/contrib/orcid_integration/orcid_oauth/orcid_oauth.module
+++ b/www/sites/all/modules/contrib/orcid_integration/orcid_oauth/orcid_oauth.module
@@ -1,0 +1,182 @@
+<?php
+
+/**
+ * Implements hook_menu().
+ */
+function orcid_oauth_menu() {
+  $items['user/%user/orcid_oauth'] = array(
+    'title' => 'ORCID via OAuth',
+    'page callback' => 'orcid_oauth_connector',
+    'access arguments' => array('view own profile'),
+  );
+  $items['user/%user/orcid_thankyou'] = array(
+    'title' => 'ORCID – Thank you',
+    'page callback' => 'orcid_oauth_thankyou',
+    'access arguments' => array('view own profile'),
+    'type' => MENU_NORMAL_ITEM,
+  );
+
+  return $items;
+}
+
+/**
+ * Implementation of hook_form_FORM_ID_alter().
+ */
+function orcid_oauth_form_orcid_integration_map_account_alter(&$form, &$form_state, $form_id) {
+  // replace form with item templat from orcid_oauth
+  unset($form['existing']);
+  unset($form['mapping']);
+  unset($form['create']);
+  // unset($form['#submit']);
+  $form['orcid_button'] = array(
+    '#type' => 'item',
+    '#theme' => 'orcid_oauth_connect',
+  );
+}
+
+/**
+ * Implementation of hook_preprocess_orcid_oauth_connect().
+ */
+function orcid_oauth_preprocess_orcid_oauth_connect(&$vars) {
+  global $base_url;
+  // build $vars with account and orcid values to pass to theme function
+  $vars['account'] = user_load(arg(1));
+  $vars['orcid']['main_url'] = variable_get('orcid_integration_main_url', 'https://sandbox.orcid.org/');
+  $vars['orcid']['client_id'] = variable_get('orcid_integration_api_client_id');
+  $vars['orcid']['redirect_url'] = variable_get('orcid_integration_api_redirect_url', $base_url);
+}
+
+/*
+ * Returns a link to the users ORCID record or a button to connect to ORCID's OAuth API
+ */
+function orcid_oauth_connector() {
+  global $base_url;
+  // build $vars with account and orcid values to pass to theme function
+  $vars['account'] = user_load(arg(1));
+  $vars['orcid']['main_url'] = variable_get('orcid_integration_main_url', 'https://sandbox.orcid.org/');
+  $vars['orcid']['client_id'] = variable_get('orcid_integration_api_client_id');
+  $vars['orcid']['redirect_url'] = variable_get('orcid_integration_api_redirect_url', $base_url);
+  // check if the user (via /user/%/orcid_oauth not logged in user) has a connected ORCID id.
+  if (array_key_exists('orcid_response', $vars['account']->data)) {
+    if (array_key_exists('orcid', $vars['account']->data['orcid_response'])) {
+      return theme('orcid_oauth_connected', $vars);
+    }
+  } elseif (array_key_exists('orcid_code', $vars['account']->data)) {
+    // call API with code/token to get ORCID id
+    orcid_oauth_get_orcid_id($vars);
+    return theme('orcid_oauth_connect', $vars);
+  } else {
+    return theme('orcid_oauth_connect', $vars);
+  }
+}
+
+/*
+ * Returns a close button for the connect to ORCID's popup window
+ * and saves the orcid code to the user's orcid code field.
+ */
+function orcid_oauth_thankyou() {
+  // get ?code=xxxxxx param
+  $qparams = drupal_get_query_parameters();
+  // load user account from redirection
+  $vars['account'] = user_load(arg(1));
+  // assign code to data array
+  $edit = array(
+    'data' => array(
+      'orcid_code' => $qparams['code'],
+    ),
+  );
+  // save code to user['data'] via $edit param
+  user_save($vars['account'], $edit);
+	return theme('orcid_oauth_thankyou', $vars);
+}
+
+/**
+ * Implements hook_theme().
+ */
+function orcid_oauth_theme($existing, $type, $theme, $path) {
+  return array(
+    'orcid_oauth_connect' => array(
+      'template' => 'orcid-oauth-connect',
+      'variables' => array(),
+    ),
+    'orcid_oauth_connected' => array(
+      'template' => 'orcid-oauth-connected',
+    ),
+    'orcid_oauth_thankyou' => array(
+      'template' => 'orcid-oauth-thankyou',
+    ),
+  );
+}
+
+/**
+ * Implements hook_page_build().
+ */
+function orcid_oauth_page_build(&$page) {
+	// attach css to oauth connect page TODO: not every page
+  $page['page_bottom']['orcid_oauth']['#attached']['css'] = array(
+  	drupal_get_path('module', 'orcid_oauth') . '/orcid_oauth.css',
+	);
+  // moved js to inline via template
+ //  $page['page_bottom']['orcid_oauth']['#attached']['js'] = array(
+ //  	drupal_get_path('module', 'orcid_oauth') . '/orcid_oauth.js',
+	// );
+}
+
+function orcid_oauth_access() {
+	// return TRUE;
+}
+
+function orcid_oauth_get_orcid_id($vars) {
+  $service = wsclient_service_load('orcid_oauth_service');
+  $client_secret = variable_get('orcid_integration_api_client_secret');
+  try {
+    // call ORCID service with params to override defaults
+    $response = $service->getOrcidId(
+      $vars['orcid']['client_id'],
+      $client_secret,
+      'authorization_code',
+      $vars['account']->data['orcid_code']
+    );
+    $vars['account']->field_orcid_id[LANGUAGE_NONE][0]['value'] = $response['orcid'];
+    // save orcid response to user data array
+    user_save($vars['account'], array(
+      'data' => array(
+        'orcid_response' => $response,
+        'orcid_response_timestamp' => time(),
+        // TODO: use this in calls later to see if we have to get a new access_token
+      )
+    ));
+  }
+  catch (WSClientException $exception) {
+    return false;
+  }
+  return $response;
+}
+
+/*
+ * Implements hook_default_wsclient_service().
+ */
+function orcid_oauth_default_wsclient_service() {
+  // construct ORCID service
+  $service = new WSClientServiceDescription();
+  $service->name = 'orcid_oauth_service';
+  $service->label = 'ORCID Service';
+  $service->url = 'https://pub.sandbox.orcid.org/oauth/token';
+  // TODO: make this url ^^ dynamic
+  $service->type = 'rest';
+  // construct operations
+  $operation['parameter']['client_id'] = array('type' => 'text', 'default_value' => '');
+  $operation['parameter']['client_secret'] = array('type' => 'text', 'default_value' => '');
+  $operation['parameter']['grant_type'] = array('type' => 'text', 'default_value' => 'authorization_code');
+  $operation['parameter']['code'] = array('type' => 'text', 'default_value' => '');
+  $operation['type'] = 'POST';
+  // add operations to service
+  $service->operations['getOrcidId'] = $operation;
+  $service->settings['curl options'] = array('Accept: application/json');
+  // add service to services array
+  $services[$service->name] = $service;
+  // clear $operation array for possible later use
+  $operation = array();
+
+  return $services;
+}


### PR DESCRIPTION
 * interacts with orcid_integration (new dependency) module by modifying form
 * various code cleanup and prep for eventual move to be a sub-module of orcid_integration
pc = cherry-picked

DRUP-675: moved orcid_oauth module inside of orcid_integration module

@akohler please deploy to test and prod. These involve new modules that are safe to go to prod in code. Will turn on in prod after a bit more testing in www-test.