### PR TITLE
DRUP-746: #ready shib-o-lize's drupal user accounts created via ORCID batch script

### DIFF
--- a/www/sites/all/modules/contrib/orcid_integration/orcid_integration_provision/orcid_integration_provision.info
+++ b/www/sites/all/modules/contrib/orcid_integration/orcid_integration_provision/orcid_integration_provision.info
@@ -1,7 +1,7 @@
 name = "ORCID Integration Provision"
 description = "Provision new accounts based on a CSV file. Meant as example (primary usage for UCLA Libraries)."
 core = "7.x"
-version = "7.x-1.1"
+version = "7.x-1.2"
 package = "Other"
 dependencies[] = orcid_integration
 files[] = parsecsv/parsecsv.lib.php

--- a/www/sites/all/modules/contrib/orcid_integration/orcid_integration_provision/orcid_integration_provision.module
+++ b/www/sites/all/modules/contrib/orcid_integration/orcid_integration_provision/orcid_integration_provision.module
@@ -80,10 +80,12 @@ function orcid_integration_provision_import_user($data, &$context) {
                 }
                 $conflict_orcids[] = $orcid_account['orcid-profile']['orcid-identifier']['path'];
                 $conflict = TRUE;
+                // break out of both loops
                 break 2;
               }
               else {
                 $orcid = $orcid_account['orcid-profile']['orcid-identifier']['path'];
+                // break out of both loops
                 break 2;
               }
             }
@@ -94,7 +96,7 @@ function orcid_integration_provision_import_user($data, &$context) {
     if (!empty($conflict)) {
       $orcid = NULL;
     }
-
+    // set original email from Drupal user
     $account->mail = $original_mail;
     // Claim account if same email exists and there were no conflicts.
     if (empty($orcid) && !$conflict) {
@@ -106,12 +108,8 @@ function orcid_integration_provision_import_user($data, &$context) {
       $account->field_orcid_id[LANGUAGE_NONE][0] = array(
         'value' => $orcid,
       );
-      // if first and last name fields exist and are empty populate them
-      if (property_exists($account, 'field_first_name') && property_exists($account, 'field_last_name')) {
-        $account->field_first_name[LANGUAGE_NONE][0]['value'] = $data['first_name'];
-        $account->field_last_name[LANGUAGE_NONE][0]['value'] = $data['last_name'];
-      }
-      user_save($account);
+      // save user and pass extra data
+      user_save($account, $data);
       drupal_set_message(t('User %user claimed ORCID: @orcid', array('%user' => $account->name, '@orcid' => $orcid)));
     }
   }
@@ -164,9 +162,15 @@ function orcid_integration_provision_import_finished($success, $results, $operat
 function _orcid_integration_provision_create_new_account($data) {
   $user_info = array(
     'name' => $data['username'],
+    'first_name' => $data['first_name'],
+    'last_name' => $data['last_name'],
     'mail' => $data['email'][0],
     'pass' => user_password(),
     'status' => 1,
+    'data' => array(
+      // flags user as coming from an ORCID batch process
+      'from_orcid_batch' => TRUE,
+    ),
   );
   $account = new stdClass();
   $account = user_save($account, $user_info);

--- a/www/sites/all/modules/custom/orcid_integration_extras/orcid_integration_extras.info
+++ b/www/sites/all/modules/custom/orcid_integration_extras/orcid_integration_extras.info
@@ -2,5 +2,5 @@ name = ORCID Integration - extras
 description = Extra tweaks to the Orcid integration that are specific to UCLA Library and do not belong in the main orcid_integration module
 package = ORCID
 core = 7.x
-version = 7.x-1.0
+version = 7.x-1.1
 dependencies[] = orcid_integration

--- a/www/sites/all/modules/custom/orcid_integration_extras/orcid_integration_extras.module
+++ b/www/sites/all/modules/custom/orcid_integration_extras/orcid_integration_extras.module
@@ -6,6 +6,41 @@
  * Implementation of hook_form_user_profile_form_alter().
  */
  function orcid_integration_extras_form_user_profile_form_alter(&$form, &$form_state, $form_id) {
- 	// hide the ORCID field on the user edit form (aka user_profile_form) via: DRUP-668
+  // hide the ORCID field on the user edit form (aka user_profile_form) via: DRUP-668
   $form['field_orcid_id']['#access'] = FALSE;
+}
+
+/**
+ * Implements hook_user_presave().
+ */
+function orcid_integration_extras_user_presave(&$edit, $account, $category) {
+  // set first name and last name for new orcid users
+  if (array_key_exists('first_name', $edit) && array_key_exists('last_name', $edit) ) {
+    $edit['field_first_name'][LANGUAGE_NONE][0]['value'] = $edit['first_name'];
+    $edit['field_last_name'][LANGUAGE_NONE][0]['value'] = $edit['last_name'];
+  }
+}
+
+/**
+ * Implements hook_user_insert().
+ */
+function orcid_integration_extras_user_insert(&$edit, $account, $category) {
+  // shib-o-lize new users if the were created by orcid batch script
+  if ($account->data['from_orcid_batch'] && module_exists('shib_auth') ) {
+    // update shib_auth module tables after "Pre-creating users" with ORCID batch
+    // per documentation: https://wiki.aai.niif.hu/index.php/DrupalShibbolethReadmeDev#Pre-creating_users
+    db_insert('shib_authmap')
+      ->fields(array(
+        'uid' => $account->uid,
+        'targeted_id' => $account->name,
+      ))
+      ->execute();
+    db_insert('authmap')
+      ->fields(array(
+        'uid' => $account->uid,
+        'authname' => $account->name,
+        'module' => 'shib_auth',
+      ))
+      ->execute();
+  }
 }


### PR DESCRIPTION
This PR contains 2 commits:
1. DRUP-741: revisits the wrong name issue and fixes it better than...
f2f5fcfc7063a7436ae43650dcabea353c95bba1 did by passing the data to hook_user_presave() is a custom UCLA specific module rather than the main orcid module.
2. DRUP-746: #ready shib-o-lize's drupal user accounts created via ORCID batch script
by updating some of shib_auth's tables while the users are saved during the batch

@akohler please deploy to ```www-test```. 

I will then test by creating a new Drupal user via the ORCID batch process and then attempt to login to ```www-test``` via shib_auth with said new user.