### PR TITLE
DRUP-751: #ready flags user as possibly having an ORCID when batch re…

### DIFF
--- a/www/sites/all/modules/contrib/orcid_integration/orcid_integration.info
+++ b/www/sites/all/modules/contrib/orcid_integration/orcid_integration.info
@@ -1,5 +1,5 @@
 name = ORCID Integration
 description = Integration with the ORCID system
 core = 7.x
-version = 7.x-1.3
+version = 7.x-1.4
 package = ORCID

--- a/www/sites/all/modules/contrib/orcid_integration/orcid_integration.module
+++ b/www/sites/all/modules/contrib/orcid_integration/orcid_integration.module
@@ -211,11 +211,25 @@ function orcid_integration_provision_new_account($email, $first_name, $last_name
     'data' => theme('orcid_integration_xml_bio', array('email' => $email, 'first_name' => $first_name, 'last_name' => $last_name)),
   );
   $response = drupal_http_request($api_url . ORCID_INTEGRATION_API_VERSION . '/orcid-profile', $options);
+  // if OCRID account created
   if ($response->code == "201" && $response->status_message == 'Created') {
     $location = $response->headers['location'];
     $location = str_replace('/orcid-profile', '', $location);
     $location = trim(basename($location));
     return $location;
+  }
+  // if ORCID user email exists
+  elseif ($response->code == "400" && $response->status_message == "Bad Request") {
+    dpm(get_defined_vars(), "This user might have a private email in the ORCID system:");
+    $account = user_load_by_mail($email);
+    dpm($account, "\$account");
+    $edit = array(
+      'data' => array(
+        'orcid_integration_may_have_orcid' => TRUE,
+      )
+    );
+    user_save($account, $edit);
+    dpm(user_load($account->uid), "user_load():");
   }
   else {
     drupal_set_message($response->error, 'error');

--- a/www/sites/all/modules/contrib/orcid_integration/orcid_integration_provision/orcid_integration_provision.module
+++ b/www/sites/all/modules/contrib/orcid_integration/orcid_integration_provision/orcid_integration_provision.module
@@ -169,7 +169,7 @@ function _orcid_integration_provision_create_new_account($data) {
     'status' => 1,
     'data' => array(
       // flags user as coming from an ORCID batch process
-      'from_orcid_batch' => TRUE,
+      'orcid_integration_provision_from_batch' => TRUE,
     ),
   );
   $account = new stdClass();


### PR DESCRIPTION
…turns a 400 response

also renames array key for signifying user was created in an ORCID batch to a more standard name

@akohler please deploy this and #106 to `www-test`. Thank you!