### PR TITLE
DRUP-766: #ready removes the "Member for:" data on the User page

### DIFF
--- a/www/sites/all/modules/features/uclalib_users/uclalib_users.module
+++ b/www/sites/all/modules/features/uclalib_users/uclalib_users.module
@@ -22,3 +22,19 @@ function uclalib_users_username_alter(&$name, $account) {
 function uclalib_users_form_user_profile_form_alter(&$form, &$form_state, $form_id) {
   $form['account']['name']['#title'] = $form['account']['name']['#title'] . " (UID)";
 }
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function uclalib_users_preprocess_user_profile(&$variables) {
+  // DRUP-766: removes the "Member for:" data on the User page
+  unset($variables['user_profile']['summary']['member_for']);
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function uclalib_users_preprocess_user_profile_category(&$variables) {
+  // DRUP-766: Removes the "History" heading above the "Member for:" on the user page
+  $variables['title'] = "";
+}


### PR DESCRIPTION
I will doploy this along with #116 