### PR TITLE
DRUP-578: #ready includes final changes for all sub-tickets

### DIFF
--- a/www/sites/all/modules/contrib/orcid_integration/orcid_integration.info
+++ b/www/sites/all/modules/contrib/orcid_integration/orcid_integration.info
@@ -1,5 +1,5 @@
 name = ORCID Integration
 description = Integration with the ORCID system
 core = 7.x
-version = 7.x-1.4
+version = 7.x-1.5
 package = ORCID

--- a/www/sites/all/modules/contrib/orcid_integration/orcid_integration.module
+++ b/www/sites/all/modules/contrib/orcid_integration/orcid_integration.module
@@ -220,16 +220,13 @@ function orcid_integration_provision_new_account($email, $first_name, $last_name
   }
   // if ORCID user email exists
   elseif ($response->code == "400" && $response->status_message == "Bad Request") {
-    dpm(get_defined_vars(), "This user might have a private email in the ORCID system:");
     $account = user_load_by_mail($email);
-    dpm($account, "\$account");
     $edit = array(
       'data' => array(
         'orcid_integration_may_have_orcid' => TRUE,
       )
     );
     user_save($account, $edit);
-    dpm(user_load($account->uid), "user_load():");
   }
   else {
     drupal_set_message($response->error, 'error');

--- a/www/sites/all/modules/contrib/orcid_integration/orcid_integration_provision/orcid_integration_provision.info
+++ b/www/sites/all/modules/contrib/orcid_integration/orcid_integration_provision/orcid_integration_provision.info
@@ -1,7 +1,7 @@
 name = "ORCID Integration Provision"
 description = "Provision new accounts based on a CSV file. Meant as example (primary usage for UCLA Libraries)."
 core = "7.x"
-version = "7.x-1.2"
+version = "7.x-1.3"
 package = "Other"
 dependencies[] = orcid_integration
 files[] = parsecsv/parsecsv.lib.php

--- a/www/sites/all/modules/contrib/orcid_integration/orcid_integration_provision/orcid_integration_provision.module
+++ b/www/sites/all/modules/contrib/orcid_integration/orcid_integration_provision/orcid_integration_provision.module
@@ -169,7 +169,7 @@ function _orcid_integration_provision_create_new_account($data) {
     'status' => 1,
     'data' => array(
       // flags user as coming from an ORCID batch process
-      'orcid_integration_provision_from_batch' => TRUE,
+      'orcid_integration_provision_new_drupal_account_from_batch' => TRUE,
     ),
   );
   $account = new stdClass();

--- a/www/sites/all/modules/contrib/orcid_integration/orcid_oauth/orcid-oauth-thankyou.tpl.php
+++ b/www/sites/all/modules/contrib/orcid_integration/orcid_oauth/orcid-oauth-thankyou.tpl.php
@@ -1,4 +1,5 @@
-<p>Thank you for connecting your ORCID account.</p>
+<article>You linked your ORCID to your University ID.
+<p><strong>One more step</strong>: a verification email has been sent to you from orcid.org. Please <strong>follow the link</strong> within the email to verify the registered address.</p></article>
 <button id="thankyou-close">Close this window</button>
 <script type="text/javascript">
 	(function ($) {

--- a/www/sites/all/modules/contrib/orcid_integration/orcid_oauth/orcid_oauth.module
+++ b/www/sites/all/modules/contrib/orcid_integration/orcid_oauth/orcid_oauth.module
@@ -11,7 +11,7 @@ function orcid_oauth_menu() {
     'access arguments' => array(1),
   );
   $items['user/%user/orcid_thankyou'] = array(
-    'title' => 'ORCID – Thank you',
+    'title' => t('Thank You!'),
     'page callback' => 'orcid_oauth_thankyou',
     'access callback' => 'orcid_integration_edit_access',
     'access arguments' => array(1),

--- a/www/sites/all/modules/custom/orcid_integration_extras/orcid_integration_extras.info
+++ b/www/sites/all/modules/custom/orcid_integration_extras/orcid_integration_extras.info
@@ -2,5 +2,5 @@ name = ORCID Integration - extras
 description = Extra tweaks to the Orcid integration that are specific to UCLA Library and do not belong in the main orcid_integration module
 package = ORCID
 core = 7.x
-version = 7.x-1.1
+version = 7.x-1.2
 dependencies[] = orcid_integration

--- a/www/sites/all/modules/custom/orcid_integration_extras/orcid_integration_extras.module
+++ b/www/sites/all/modules/custom/orcid_integration_extras/orcid_integration_extras.module
@@ -26,7 +26,7 @@ function orcid_integration_extras_user_presave(&$edit, $account, $category) {
  */
 function orcid_integration_extras_user_insert(&$edit, $account, $category) {
   // shib-o-lize new users if the were created by orcid batch script
-  if ($account->data['from_orcid_batch'] && module_exists('shib_auth') ) {
+  if ($account->data['orcid_integration_provision_new_drupal_account_from_batch'] && module_exists('shib_auth') ) {
     // update shib_auth module tables after "Pre-creating users" with ORCID batch
     // per documentation: https://wiki.aai.niif.hu/index.php/DrupalShibbolethReadmeDev#Pre-creating_users
     db_insert('shib_authmap')

--- a/www/sites/all/modules/features/uclalib_users/uclalib_users.module
+++ b/www/sites/all/modules/features/uclalib_users/uclalib_users.module
@@ -22,3 +22,19 @@ function uclalib_users_username_alter(&$name, $account) {
 function uclalib_users_form_user_profile_form_alter(&$form, &$form_state, $form_id) {
   $form['account']['name']['#title'] = $form['account']['name']['#title'] . " (UID)";
 }
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function uclalib_users_preprocess_user_profile(&$variables) {
+  // DRUP-766: removes the "Member for:" data on the User page
+  unset($variables['user_profile']['summary']['member_for']);
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function uclalib_users_preprocess_user_profile_category(&$variables) {
+  // DRUP-766: Removes the "History" heading above the "Member for:" on the user page
+  $variables['title'] = "";
+}

--- a/www/sites/all/themes/uclalib_omega/css/uclalib-omega.styles.css
+++ b/www/sites/all/themes/uclalib_omega/css/uclalib-omega.styles.css
@@ -313,7 +313,12 @@ a[href="#main-content"] {
   background: #fff;
   padding-bottom: 25px;
 }
-
+body.page-user .l-main-wrapper .l-main {
+  padding-top: 25px;
+}
+body.page-user-orcid-thankyou .l-content {
+  width: 50%;
+}
 .l-region--main-column {
   padding-top: 1em;
 }


### PR DESCRIPTION
Squashed commits include:
1. DRUP-766: removes the "Member for:" data on the User page
2. DRUP-746: #ready shib-o-lizes users properly now; DRUP-764: #ready removes debug statments
3. DRUP-763: updates ORCID thank you page with new copy

Ready for this week's deployment.