### PR TITLE
OP-827: #awaiting fixes site alert by moving the $page['help'] rendered var out of a div...

### DIFF
--- a/www/sites/all/themes/uclalib_omega/layouts/basic/basic.tpl.php
+++ b/www/sites/all/themes/uclalib_omega/layouts/basic/basic.tpl.php
@@ -11,11 +11,10 @@
       <?php print render($page['navigation']); ?>
     </div>
   </div>
-
+  <?php print render($page['help']); ?>
   <?php if ($page['highlighted']) : ?>
   <div class="l-highlighted-wrapper">
     <div class="l-highlighted">
-      <?php print render($page['help']); ?>
       <?php print render($page['highlighted']); ?>
     </div>
   </div>

--- a/www/sites/all/themes/uclalib_omega/uclalib_omega.info
+++ b/www/sites/all/themes/uclalib_omega/uclalib_omega.info
@@ -4,7 +4,7 @@ base theme = omega
 screenshot = screenshot.png
 engine = phptemplate
 core = 7.x
-version = 1.0
+version = 7.x-1.1
 
 ; ========================================
 ; Core Stylesheet Overrides


### PR DESCRIPTION
that is conditionally rendered with the page title. Now pages that don't
have titles can still have alerts.