### PR TITLE
Squashed commit for version 7.x-1.5-alpha1 of ucla_tab_search and ucl…

### DIFF
--- a/www/sites/all/modules/custom/ucla_search/includes/ucla_search_handlers.inc
+++ b/www/sites/all/modules/custom/ucla_search/includes/ucla_search_handlers.inc
@@ -18,6 +18,9 @@ function ucla_search_route_search($search_info) {
     case "articles":
       serial_solutions_360($search_info);
       break;
+    case "articlesplus":
+      summon_articlesplus($search_info);
+      break;
     case "database":
       ucla_search_database($search_info);
       break;
@@ -71,6 +74,17 @@ function serial_solutions_360($search_info) {
   $extra_params .= '&boolop1=and&term1=&field1=keyword&boolop2=and&term2=&field2=keyword&boolop4=And&term4=&field4=';
   $extra_params .= $search_info['search_year'];
   $extra_params .= str_replace(' ', '&catID=', $search_info['search_categories']);
+  $target_url .= $extra_params;
+  drupal_goto($path = $target_url);
+}
+
+function summon_articlesplus($search_info) {
+  $target_url = 'http://ucla.summon.serialssolutions.com/#!/search';
+  $extra_params = '?ho=t&l=en';
+  if ( isset($search_info['search_limit']) ) {
+    $extra_params .= '&fvf=' . $search_info['search_limit']; // debugging
+  }
+  $extra_params .= '&q=' . $search_info['search_terms'];
   $target_url .= $extra_params;
   drupal_goto($path = $target_url);
 }

--- a/www/sites/all/modules/custom/ucla_search/ucla_search.info
+++ b/www/sites/all/modules/custom/ucla_search/ucla_search.info
@@ -2,5 +2,5 @@ name = UCLA Search
 description = Routines for building searches to various targets, and for logging searches to database.
 package = UCLA Search modules
 core = 7.x
-version = "7.x-1.4"
+version = "7.x-1.5-alpha1"
 dependencies[] = views_data_export

--- a/www/sites/all/modules/custom/ucla_tab_search/ucla_tab_search.info
+++ b/www/sites/all/modules/custom/ucla_tab_search/ucla_tab_search.info
@@ -1,5 +1,5 @@
 name = UCLA Tab Search
 description = Custom tab forms for searching on the UCLA Library homepage.
 core = 7.x
-version = "7.x-1.4"
+version = "7.x-1.5-alpha1"
 dependencies[] = ucla_search

--- a/www/sites/all/modules/custom/ucla_tab_search/ucla_tab_search.module
+++ b/www/sites/all/modules/custom/ucla_tab_search/ucla_tab_search.module
@@ -149,6 +149,50 @@ can be changed via a pulldown search limit on the results screen. Many records c
   );
 
   ////////////////////////////////////////////////////////////////////////////////
+  // ArticlesPlus tab.
+  // ArticlesPlus tab.
+  // ArticlesPlus tab.
+  $form['articlesplus'] = array(
+    '#title' => t('ArticlesPlus'),
+  ) + $fieldset_default;
+  $form['articlesplus']['text_query'] = $query_textfield;
+  $form['articlesplus']['text_query']['#attributes'] = array(
+    'placeholder' => t('Search several databases at once.'),
+  );
+  $form['articlesplus']['text_query']['#field_suffix'] = t('<a href="http://ucla.summon.serialssolutions.com/#!/search">Advanced Search</a>');
+
+  $form['articlesplus']['peer_review'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Limit to peer-reviewed journals'),
+  );
+
+  $form['articlesplus']['articlesplus_search'] = $search_button;
+  $form['articlesplus']['articlesplus_search']['#name'] = 'op_articlesplus';
+
+  // 2016-02-24 akohler: I think this container markup is overly complex for most tabs... but copied/adapted from OAC tab's markup...
+  $form['articlesplus']['articlesplus_container_mel'] = array(
+    '#type' => 'container',
+    '#states' => array(
+      'visible' => array(':input[name="articleplus[catalog]"]' => array('value' => 'articleplus-Mel')),
+    ),
+    '#attributes' => array(
+      'class' => array(
+        'pane-description',
+      ),
+    ),
+  );
+  $form['articlesplus']['articlesplus_container_mel']['description'] = array(
+    '#markup' => t('
+      <strong>What am I searching?</strong>
+      <img src="http://placehold.it/150x150"
+           alt="ArticlesPlus contains journal articles, newspaper articles, ebooks, other"
+      ></br>
+      <a href="/about-articlesplus">About ArticlesPlus</a></br>
+      <a href="/search">Where else can I search?</a>
+    '),
+  );
+
+  ////////////////////////////////////////////////////////////////////////////////
   // Articles tab.
   // Articles tab.
   // Articles tab.
@@ -448,9 +492,12 @@ function ucla_tab_search_tabs_form_submit($form, &$form_state) {
   $browser_ip = (isset($_SERVER['HTTP_X_FORWARDED_FOR']) ? $_SERVER['HTTP_X_FORWARDED_FOR'] : $_SERVER['REMOTE_ADDR']);
 //  $search_form = 'ucla_tab';
 
+  // 2016-02-24 akohler: Not sure of the purpose of this array, other than to provide op_$tab names for the switch below...
   $tab_form_id_map = array(
     'books' => array('BM-CAT' => 'BM-CAT', 'BM-Mel' => 'BM-Mel'),
     'articles' => array('ART' => 'ART', 'article' => 'article'),
+    // 2016-02-24 akohler: Added simplest possible array for ArticlesPlus tab
+    'articlesplus' => array('AP' => 'AP'),
     'journals' => array('J-ALL' => 'J-ALL', 'J-E' => 'J-E'),
     'databases' => array('within' => 'within', 'starts' => 'starts'),
     'guides' => array('within' => 'within', 'starts' => 'starts'),
@@ -591,6 +638,21 @@ function ucla_tab_search_tabs_form_submit($form, &$form_state) {
 	  'browser_ip' => $browser_ip,
 	  'search_form' => 'MA',
 	  );
+	break;
+
+        case 'edit-articlesplus':
+	  // Put form info into array expected by search logger / handlers
+	  $search_info = array (
+	  'search_target' => 'articlesplus',
+	  'search_terms' => $form_state['values']['articlesplus']['text_query'],
+	  'search_date' => $search_date,
+	  'browser_ip' => $browser_ip,
+	  'search_form' => 'AP',
+	  );
+	  // Add optional limit
+	  if ($form_state['values']['articlesplus']['peer_review'] == 1) {
+	    $search_info['search_limit'] = 'IsScholarly,true,f';
+	  }
 	break;
 
         default:


### PR DESCRIPTION
…a_search modules.

This adds an ArticlesPlus tab to the homepage search form.

commit 9f471f6b978478dfe8b0a89eccd5c8a4beb6b469
Author: Andy Kohler <akohler@library.ucla.edu>
Date:   Wed Feb 24 14:15:50 2016 -0900

    DRUP-815: Add description text and placeholder image for ArticlesPlus tab

commit 8290fe4e10ad40b0c40039fd1bc7549ede6d066f
Author: Andy Kohler <akohler@library.ucla.edu>
Date:   Wed Feb 24 13:41:09 2016 -0900

    DRUP-817: Fix peer review limit to work correctly

commit a78fe41cc6a1e49ca6496d7ad5886b8bfc6e0c44
Author: Andy Kohler <akohler@library.ucla.edu>
Date:   Wed Feb 24 12:39:48 2016 -0900

    DRUP-813: Increment version to 7.x-1.5-alpha1

commit f669849589a0236bdd419621110ce2fbbaf28a18
Author: Andy Kohler <akohler@library.ucla.edu>
Date:   Wed Feb 24 12:36:30 2016 -0900

    DRUP-815: Add search handler for ArticlesPlus

commit acf3e177ee63d308e5c53f79be2e6fbcf2b72274
Author: Andy Kohler <akohler@library.ucla.edu>
Date:   Wed Feb 24 12:28:59 2016 -0900

    DRUP-815: Add basic mapping of ArticlesPlus search form to values for search/log handlers

commit 0c134ced5c28f2304e38010fa00582bd1887961f
Author: Andy Kohler <akohler@library.ucla.edu>
Date:   Wed Feb 24 10:46:26 2016 -0900

    DRUP-817: Add checkbox for peer review limit

commit 9ad20c1ef64ead96b45c0f7241edc44c9ac60e03
Author: Andy Kohler <akohler@library.ucla.edu>
Date:   Wed Feb 24 10:29:56 2016 -0900

    DRUP-816: Add Advanced Search link, though not opening in new tab

commit aa405795f1bac20c7875a780e275c76d1f2e9af2
Author: Andy Kohler <akohler@library.ucla.edu>
Date:   Wed Feb 24 10:22:54 2016 -0900

    DRUP-815: Add Search button to ArticlesPlus tab

commit b27e097b9c042f7f2daf2969db758d57438110ff
Author: Andy Kohler <akohler@library.ucla.edu>
Date:   Wed Feb 24 10:17:17 2016 -0900

    DRUP-815: Add ArticlesPlus to tabbed search, with basic search box