### PR TITLE
DRUP-811: #ready adds static URLS for homepage search tab widget that…

### DIFF
--- a/www/sites/all/modules/custom/ucla_tab_search/ucla_tab_search.info
+++ b/www/sites/all/modules/custom/ucla_tab_search/ucla_tab_search.info
@@ -1,5 +1,5 @@
 name = UCLA Tab Search
 description = Custom tab forms for searching on the UCLA Library homepage.
 core = 7.x
-version = "7.x-1.5-beta4"
+version = "7.x-1.5-beta5"
 dependencies[] = ucla_search

--- a/www/sites/all/modules/custom/ucla_tab_search/ucla_tab_search.js
+++ b/www/sites/all/modules/custom/ucla_tab_search/ucla_tab_search.js
@@ -1,0 +1,20 @@
+(function($) {
+  Drupal.behaviors.ucla_tab_search = {
+    attach: function (context, settings) {
+      // display the current tab based on #hash from URL
+      var hash = window.location.hash.substr(1);
+      if (settings.ucla_tab_search.ids.indexOf(hash) >= 0) {
+        $('.vertical-tabs .vertical-tab-button.selected').removeClass('selected');
+        $('.vertical-tabs .vertical-tab-button:nth-child('+ settings.ucla_tab_search.ids.indexOf(hash) +')').addClass('selected');
+        $('.vertical-tabs-panes .vertical-tabs-pane').hide();
+        $('.vertical-tabs-panes .vertical-tabs-pane#edit-'+ hash).show();
+      }
+      // set the URL #hash based on the clicking of tabs
+      $('.vertical-tab-button').mousedown(function () {
+        $(this).mouseup(function () {
+          window.location.hash = '#'+ Drupal.settings.ucla_tab_search.ids[$(this).index()+1];
+        });
+      });
+    }
+  };
+})(jQuery);

--- a/www/sites/all/modules/custom/ucla_tab_search/ucla_tab_search.module
+++ b/www/sites/all/modules/custom/ucla_tab_search/ucla_tab_search.module
@@ -419,6 +419,23 @@ The titles and abbreviations of journals subscribed to electronically by the UCL
 
 // end  code for description text  - ccthompson
 
+  // pass vertical tab id(s) to javascript for hash-landers
+  $ids = array();
+  foreach($form as $key => $element) {
+    if (substr($key, 0, 1) != '#') {
+      $ids[] = $key;
+    }
+  }
+  $form['tabs']['#attached']['js'] = array(
+    array(
+      'data' => array('ucla_tab_search' => array('ids' => $ids)),
+      'type' => 'setting'
+    ),
+    array(
+      'data' => drupal_get_path('module', 'ucla_tab_search') . '/ucla_tab_search.js'
+    )
+  );
+
   return $form;
 }
 


### PR DESCRIPTION
… highlight the desired tab

Squashed commit of the following:

commit 6c6f27bcb55e8c7902af38e90c650d29c393f7e7
Author: Casey Grzecka <cgrzecka@library.ucla.edu>
Date:   Mon Mar 14 18:21:02 2016 +0000

    adds a mouseup listener to the mousedowned object so that it is slightly less wonky, though still not perfect

commit a8bec75ec75487bc434f18b7ff41938b86d32f07
Merge: dcd49a6 afcd974
Author: Casey Grzecka <cgrzecka@library.ucla.edu>
Date:   Fri Mar 11 22:42:44 2016 +0000

    Merge branch 'search_url' of github.com:z3cka/libraryweb-site into search_url

commit dcd49a6b36f0267a6a00d8068173eba202f23904
Author: Casey Grzecka <cgrzecka@library.ucla.edu>
Date:   Fri Mar 11 22:40:25 2016 +0000

    set the URL #hash based on the clicking of tabs

commit aff341697bab63354761bced0c07fdff77eff5b7
Author: Casey Grzecka <cgrzecka@library.ucla.edu>
Date:   Wed Mar 9 19:05:46 2016 +0000

    DRUP-811: WIP on using hash-lander for home page search widget

commit afcd9741e328469acbc3a45bc7f4722e936f8700
Author: Casey Grzecka <cgrzecka@library.ucla.edu>
Date:   Fri Mar 11 22:40:25 2016 +0000

    set the URL #hash based on the clicking of tabs

commit 866d4daa7cdcfa486810174822b166971137439f
Author: Casey Grzecka <cgrzecka@library.ucla.edu>
Date:   Wed Mar 9 19:05:46 2016 +0000

    DRUP-811: WIP on using hash-lander for home page search widget