### PR TITLE
DRUP-811: Fix form handler problem caused by url hash fragments

### DIFF
--- a/www/sites/all/modules/custom/ucla_tab_search/ucla_tab_search.info
+++ b/www/sites/all/modules/custom/ucla_tab_search/ucla_tab_search.info
@@ -1,5 +1,5 @@
 name = UCLA Tab Search
 description = Custom tab forms for searching on the UCLA Library homepage.
 core = 7.x
-version = "7.x-1.5-beta5"
+version = "7.x-1.5-beta6"
 dependencies[] = ucla_search

--- a/www/sites/all/modules/custom/ucla_tab_search/ucla_tab_search.module
+++ b/www/sites/all/modules/custom/ucla_tab_search/ucla_tab_search.module
@@ -452,7 +452,6 @@ function ucla_tab_search_tabs_form_submit($form, &$form_state) {
   module_load_include('inc', 'ucla_search', 'includes/ucla_search_handlers');
   $search_date = $_SERVER['REQUEST_TIME'];
   $browser_ip = (isset($_SERVER['HTTP_X_FORWARDED_FOR']) ? $_SERVER['HTTP_X_FORWARDED_FOR'] : $_SERVER['REMOTE_ADDR']);
-//  $search_form = 'ucla_tab';
 
   // 2016-02-24 akohler: Not sure of the purpose of this array, other than to provide op_$tab names for the switch below...
   $tab_form_id_map = array(
@@ -466,14 +465,17 @@ function ucla_tab_search_tabs_form_submit($form, &$form_state) {
   );
 
   foreach ($tab_form_id_map as $tab => $maps) {
-    // The submit button name is used to decide where we are.
-    if (empty($form_state['values']["op_$tab"])) {
+    // A submitted text_query field indicates which tab/form to use.
+    if (empty($form_state['values'][$tab]['text_query'])) {
       // Not this tab.
       continue;
     }
     if (is_array($maps)) {
-	$search_form = $form_state['values']['tabs__active_tab'];
-	switch ($form_state['values']['tabs__active_tab']) {
+	// Can't trust tabs__active_tab if user came to tab via url has (e.g., site/#oac)
+	// Rely instead on $tab, from tab (form) submitted, obtained above.
+	$current_form = "edit-$tab";
+	switch ($current_form) {
+
         case 'edit-books':
 
         $form_state['values']['ucla_form_id'] = $maps[$form_state['values']['books']['catalog']];


### PR DESCRIPTION
This fixes problems with the tabbed search form submission procedure, which relied on the Drupal "tabs__active_tab" and the value of the Submit button for each "form" within the uber-form.

When form tabs are accessed directly via url hash fragments, tabs__active_tab remains at the default, the first "Books" form.  Also, depending on whether the user clicks the "Search" button or presses enter, the submitted form data varies such that the value of the Submit button is no longer reliable.

The handler now looks for a non-empty "text_query" field, which is required (semantically, if not technically...) on each form.  This is used to identify the active tab/form, so that the search is correctly logged and routed to the appropriate remote system to execute.

@z3cka : Please review and merge/deploy to www-test.  I've tested pretty thoroughly on my dev but this needs a full workout on test.