### PR TITLE
DRUP-873 #ready Version 7.x-1.5-beta5 of ucla_search.

### DIFF
--- a/www/sites/all/modules/custom/ucla_search/includes/ucla_search_logger.inc
+++ b/www/sites/all/modules/custom/ucla_search/includes/ucla_search_logger.inc
@@ -8,7 +8,7 @@
  * Logs search info to database.
  */
 function ucla_search_log_search($search_info) {
-  // Only certain elements are logged
+  // These data elements should always be present.
   $data = array (
     'search_target' => $search_info['search_target'],
     'search_terms' => $search_info['search_terms'],
@@ -16,6 +16,18 @@ function ucla_search_log_search($search_info) {
     'browser_ip' => $search_info['browser_ip'],
     'search_form' => $search_info['search_form'],
   );
+  // These elements are optional (user-selected, or only on certain forms).
+  if (isset($search_info['search_code'])) {
+    $data['search_code'] = $search_info['search_code'];
+  }
+  if (isset($search_info['search_limit'])) {
+    $data['search_limit'] = $search_info['search_limit'];
+  }
+  if (isset($search_info['search_type'])) {
+    $data['search_type'] = $search_info['search_type'];
+  }
+
+  // Store the data in the database.
   db_insert('ucla_search_log')->fields($data)->execute();
 }
 

--- a/www/sites/all/modules/custom/ucla_search/ucla_search.info
+++ b/www/sites/all/modules/custom/ucla_search/ucla_search.info
@@ -2,5 +2,5 @@ name = UCLA Search
 description = Routines for building searches to various targets, and for logging searches to database.
 package = UCLA Search modules
 core = 7.x
-version = "7.x-1.5-beta4"
+version = "7.x-1.5-beta5"
 dependencies[] = views_data_export

--- a/www/sites/all/modules/custom/ucla_search/ucla_search.install
+++ b/www/sites/all/modules/custom/ucla_search/ucla_search.install
@@ -43,6 +43,24 @@ function ucla_search_schema() {
         'not null' => TRUE,
         'default' => 'ucla_search'
       ),
+      'search_limit' => array(
+        'description' => 'Optional limit entered by user',
+        'type' => 'varchar',
+        'length' => 25,
+        'not null' => FALSE,
+      ),
+      'search_code' => array(
+        'description' => 'Search code (index type) used by some forms',
+        'type' => 'varchar',
+        'length' => 10,
+        'not null' => FALSE,
+      ),
+      'search_type' => array(
+        'description' => 'Search type (starts, contains etc.) used by some forms',
+        'type' => 'varchar',
+        'length' => 10,
+        'not null' => FALSE,
+      ),
     ),
     'primary key' => array('search_date', 'browser_ip')
   );
@@ -111,3 +129,16 @@ function ucla_search_update_7101() {
   db_add_field($table, $field, $schema['fields'][$field]);
 }
 
+/**
+ * Update logging table by adding new columns for search codes, limits and types.
+ */
+function ucla_search_update_7102() {
+  // Get complete schema (defined in hook_schema above)
+  $table = 'ucla_search_log';
+  $schema = drupal_get_schema_unprocessed('ucla_search', $table);
+  // Add new fields, defined in schema above
+  $fields = array('search_code', 'search_limit', 'search_type');
+  foreach ($fields as $field) {
+    db_add_field($table, $field, $schema['fields'][$field]);
+  }
+}

--- a/www/sites/all/modules/custom/ucla_search/ucla_search.views.inc
+++ b/www/sites/all/modules/custom/ucla_search/ucla_search.views.inc
@@ -33,6 +33,9 @@ function ucla_search_views_data() {
       'handler' => 'views_handler_field_date',
       'click sortable' => TRUE,
     ),
+    'sort' => array(
+      'handler' => 'views_handler_sort_date',
+    ),
     'filter' => array(
       'handler' => 'views_handler_filter_date',
       'allow empty' => TRUE,
@@ -77,6 +80,36 @@ function ucla_search_views_data() {
   $data['ucla_search_log']['search_form'] = array(
     'title' => t('Search Form'),
     'help' => t('Form which submitted the search'),
+    'field' => array(
+      'handler' => 'views_handler_field',
+      'click sortable' => TRUE,
+    ),
+  );
+
+  // search_code column
+  $data['ucla_search_log']['search_code'] = array(
+    'title' => t('Search Code'),
+    'help' => t('Search/index code (when relevant)'),
+    'field' => array(
+      'handler' => 'views_handler_field',
+      'click sortable' => TRUE,
+    ),
+  );
+
+  // search_limit column
+  $data['ucla_search_log']['search_limit'] = array(
+    'title' => t('Search Limit'),
+    'help' => t('Search limit (when relevant)'),
+    'field' => array(
+      'handler' => 'views_handler_field',
+      'click sortable' => TRUE,
+    ),
+  );
+
+  // search_type column
+  $data['ucla_search_log']['search_type'] = array(
+    'title' => t('Search Type'),
+    'help' => t('Search type (when relevant)'),
     'field' => array(
       'handler' => 'views_handler_field',
       'click sortable' => TRUE,

--- a/www/sites/all/modules/custom/ucla_search/views/search_log_data.inc
+++ b/www/sites/all/modules/custom/ucla_search/views/search_log_data.inc
@@ -84,6 +84,23 @@ $handler->display->display_options['fields']['search_terms']['field'] = 'search_
 $handler->display->display_options['fields']['search_form']['id'] = 'search_form';
 $handler->display->display_options['fields']['search_form']['table'] = 'ucla_search_log';
 $handler->display->display_options['fields']['search_form']['field'] = 'search_form';
+/* Field: Search data: Search Code */
+$handler->display->display_options['fields']['search_code']['id'] = 'search_code';
+$handler->display->display_options['fields']['search_code']['table'] = 'ucla_search_log';
+$handler->display->display_options['fields']['search_code']['field'] = 'search_code';
+/* Field: Search data: Search Limit */
+$handler->display->display_options['fields']['search_limit']['id'] = 'search_limit';
+$handler->display->display_options['fields']['search_limit']['table'] = 'ucla_search_log';
+$handler->display->display_options['fields']['search_limit']['field'] = 'search_limit';
+/* Field: Search data: Search Type */
+$handler->display->display_options['fields']['search_type']['id'] = 'search_type';
+$handler->display->display_options['fields']['search_type']['table'] = 'ucla_search_log';
+$handler->display->display_options['fields']['search_type']['field'] = 'search_type';
+/* Sort criterion: Search data: Search Date */
+$handler->display->display_options['sorts']['search_date']['id'] = 'search_date';
+$handler->display->display_options['sorts']['search_date']['table'] = 'ucla_search_log';
+$handler->display->display_options['sorts']['search_date']['field'] = 'search_date';
+$handler->display->display_options['sorts']['search_date']['order'] = 'DESC';
 /* Filter criterion: Search data: Search Date */
 $handler->display->display_options['filters']['search_date']['id'] = 'search_date';
 $handler->display->display_options['filters']['search_date']['table'] = 'ucla_search_log';


### PR DESCRIPTION
Adds 3 columns for logging form elements not used on all tabs:
* search code (UCLA Library Catalog index code)
* search limit (Summon ArticlesPlus peer review limit)
* search type (UCelinks/SFX/Catalog contains/startswith/exact)

Requires database update, and possibly reversion of
search_log_data view.

commit 2a11089519680bf82e062f0cbb5ce2ba5efd5543
Author: Andy Kohler <akohler@library.ucla.edu>
Date:   Mon Mar 21 21:27:03 2016 -0800

    DRUP-873: Increment ucla_search version

commit e2e084ddf562a17e26b2488facd57ecf55cfde27
Author: Andy Kohler <akohler@library.ucla.edu>
Date:   Mon Mar 21 21:14:46 2016 -0800

    DRUP-873: Add new database columns to views; change default sort to date descending

commit 9e133aef4dcdf8d2ccc262f4a9fe4128ef117dd4
Author: Andy Kohler <akohler@library.ucla.edu>
Date:   Mon Mar 21 17:27:26 2016 -0800

    DRUP-873: Log relevant form elements to new database columns

commit 057423c5ba364e0f6a17afb499f6b4cd4d1636fb
Author: Andy Kohler <akohler@library.ucla.edu>
Date:   Mon Mar 21 17:16:42 2016 -0800

    DRUP-873: Rename search_limits column to search_limit for consistency

commit f3d101d93492d0bd3e56d2cae3d178f336d93bd1
Author: Andy Kohler <akohler@library.ucla.edu>
Date:   Mon Mar 21 16:55:28 2016 -0800

    DRUP-873: Add search_code and search_type columns to ucla_search_log schema

commit 6e50c0b497353baed95d9a1fa5dc3115fd369c18
Author: Andy Kohler <akohler@library.ucla.edu>
Date:   Mon Mar 21 16:12:33 2016 -0800

    DRUP-873: Add search_limit column to ucla_search_log schema