### PR TITLE
UCLALIB-249: Reapply PATCH for Panels window title

### DIFF
--- a/www/PATCHES.txt
+++ b/www/PATCHES.txt
@@ -39,8 +39,8 @@ https://www.drupal.org/node/2018075
 https://www.drupal.org/files/issues/media_filter_float_delegate-2018075-8.patch
 
 Panels - Allow users to manually control window title.
-https://drupal.org/node/2262173
-https://drupal.org/files/issues/panels-allow_users_control_window_title-2262173-4.patch
+https://www.drupal.org/node/2262173
+https://www.drupal.org/files/issues/panels-allow_users_control_window_title-2262173-16.patch
 
 Redirect - Enable wordpress_migrate to function properly.
 Support migrate module: Destination handler class

--- a/www/sites/all/modules/contrib/panels/includes/display-edit.inc
+++ b/www/sites/all/modules/contrib/panels/includes/display-edit.inc
@@ -246,8 +246,17 @@ function panels_edit_display_settings_form($form, &$form_state) {
       '#maxlength' => 255,
     );
 
+    $form['display_title']['window_title'] = array(
+      '#type' => 'textfield',
+      '#default_value' => $display->window_title,
+      '#title' => t('Window Title'),
+      '#description' => t('The window title of this panel, as shown in the browser\'s title bar. If left blank, a default title will be used.'),
+      '#maxlength' => 255,
+    );
+
     if (!empty($display->context)) {
       $form['display_title']['title']['#description'] .= ' ' . t('You may use substitutions in this title.');
+      $form['display_title']['window_title']['#description'] .= ' ' . t('You may use substitutions in this title.');
 
       // We have to create a manual fieldset because fieldsets do not support IDs.
       // Use 'hidden' instead of 'markup' so that the process will run.
@@ -324,5 +333,9 @@ function panels_edit_display_settings_form_submit($form, &$form_state) {
   if (isset($form_state['values']['display_title']['title'])) {
     $display->title = $form_state['values']['display_title']['title'];
     $display->hide_title = $form_state['values']['display_title']['hide_title'];
+  }
+
+  if (isset($form_state['values']['display_title']['window_title'])) {
+    $display->window_title = $form_state['values']['display_title']['window_title'];
   }
 }

--- a/www/sites/all/modules/contrib/panels/panels.install
+++ b/www/sites/all/modules/contrib/panels/panels.install
@@ -47,7 +47,20 @@ function panels_requirements_install() {
 function panels_schema() {
   // This should always point to our 'current' schema. This makes it relatively
   // easy to keep a record of schema as we make changes to it.
-  return panels_schema_8();
+  return panels_schema_9();
+}
+
+function panels_schema_9() {
+  $schema = panels_schema_8();
+
+  // Add the window_title column.
+  $schema['panels_display']['fields']['window_title'] = array(
+    'type' => 'varchar',
+    'length' => '255',
+    'default' => '',
+  );
+
+  return $schema;
 }
 
 function panels_schema_8() {
@@ -606,4 +619,24 @@ function panels_update_7306() {
         ->execute();
     }
   }
+}
+
+/**
+ * Adding window title field to panels displays.
+ */
+function panels_update_7307() {
+  // Load the schema.
+  $schema = panels_schema_9();
+
+  // Add the window_title column to the display table.
+  $table = 'panels_display';
+  $field = 'window_title';
+  // Due to a previous failure, the column may already exist:
+  if (!db_field_exists($table, $field)) {
+    $spec = $schema[$table]['fields'][$field];
+    db_add_field($table, $field, $spec);
+    return t('Added panels_display.window_title column.');
+  }
+
+  return t('window_title column already present in the panels_display table.');
 }

--- a/www/sites/all/modules/contrib/panels/panels.module
+++ b/www/sites/all/modules/contrib/panels/panels.module
@@ -2018,4 +2018,29 @@ function panels_preprocess_html(&$vars) {
   if (!empty($panel_body_css['body_classes_to_add'])) {
     $vars['classes_array'][] = check_plain($panel_body_css['body_classes_to_add']);
   }
+
+  // Set window title if manually configured.
+  $tasks = page_manager_get_current_page();
+  if (isset($tasks['handler'])) {
+    if (strpos($tasks['handler']->handler, 'panelizer') === 0) {
+
+      // Get the display for panelized entities.
+      $display = $tasks['contexts'][$tasks['handler']->conf['context']]->data->panelizer['page_manager']->display;
+    }
+    else {
+
+      // Get the display for page manager pages.
+      $display = $tasks['handler']->conf['display'];
+    }
+
+    if (!empty($display->window_title)) {
+      $display_context = $display->context;
+
+      // Look for any placeholder tokens in the title and convert them for this display.
+      $head_title = ctools_context_keyword_substitute($display->window_title, array(), $display_context);
+
+      // Set the window title.
+      $vars['head_title'] = $head_title;
+    }
+  }
 }


### PR DESCRIPTION
Issue: https://www.drupal.org/node/2262173

@z3cka This patch was lost during the Panels security upgrade, and is affecting the UCLA Library site.

Compare the window title of the Homepage on http://www-test.library.ucla.edu/
to production: http://www.library.ucla.edu/

I've rerolled the patch and updated the issue queue on Drupal.org with a new version
that applies cleanly after the security release. An RTBC there would be appreciated.