### PR TITLE
DRUP-1011: #ready adds patch that allows php to continue even if a ctools...

### DIFF
--- a/www/PATCHES.txt
+++ b/www/PATCHES.txt
@@ -15,6 +15,9 @@ https://www.drupal.org/files/issues/make_ckeditor_plugin-2159403-90.patch
 Ctools - hide empty page title pane when wrapper tag is used
 https://drupal.org/node/2265451
 https://drupal.org/files/issues/ctools-hide-empty-page-title-with-wrapper-tag-2265451.patch
+Ctools - ctools calling missing file
+https://www.drupal.org/node/1775612
+https://www.drupal.org/files/plugin-load-use-include-1775612-3.patch
 
 Facetapi_bonus - add plugin filter to hide facet count.
 https://drupal.org/node/2266717

--- a/www/sites/all/modules/contrib/ctools/includes/plugins.inc
+++ b/www/sites/all/modules/contrib/ctools/includes/plugins.inc
@@ -474,7 +474,7 @@ function ctools_plugin_load_includes($info, $filename = NULL) {
         }
         else {
 
-          require_once DRUPAL_ROOT . '/' . $file->uri;
+          include_once DRUPAL_ROOT . '/' . $file->uri;
           // .inc files have a special format for the hook identifier.
           // For example, 'foo.inc' in the module 'mogul' using the plugin
           // whose hook is named 'borg_type' should have a function named (deep breath)

--- a/www/sites/all/modules/contrib/ctools/plugin-load-use-include-1775612-3.patch
+++ b/www/sites/all/modules/contrib/ctools/plugin-load-use-include-1775612-3.patch
@@ -1,0 +1,13 @@
+diff --git a/includes/plugins.inc b/includes/plugins.inc
+index 0363fcb..24f7751 100644
+--- a/includes/plugins.inc
++++ b/includes/plugins.inc
+@@ -472,7 +472,7 @@ function ctools_plugin_load_includes($info, $filename = NULL) {
+         }
+         else {
+ 
+-          require_once DRUPAL_ROOT . '/' . $file->uri;
++          include_once DRUPAL_ROOT . '/' . $file->uri;
+           // .inc files have a special format for the hook identifier.
+           // For example, 'foo.inc' in the module 'mogul' using the plugin
+           // whose hook is named 'borg_type' should have a function named (deep breath)


### PR DESCRIPTION
...plugin is missing

I'm going to deploy this to `www-test` right now and replace the "comment.inc" hack.