### PR TITLE
DRUP-1142: Update variables for Catalog linking from bookplate pages

### DIFF
--- a/www/sites/all/modules/features/uclalib_bookplates/uclalib_bookplates.info
+++ b/www/sites/all/modules/features/uclalib_bookplates/uclalib_bookplates.info
@@ -1,7 +1,7 @@
 name = UCLALIB Bookplates
 core = 7.x
 package = UCLALIB
-version = 7.x-2.9-beta1
+version = 7.x-2.9-beta2
 project = uclalib_bookplates
 dependencies[] = advanced_link
 dependencies[] = autocomplete_deluxe

--- a/www/sites/all/modules/features/uclalib_bookplates/uclalib_bookplates.module
+++ b/www/sites/all/modules/features/uclalib_bookplates/uclalib_bookplates.module
@@ -85,7 +85,7 @@ function uclalib_bookplates_admin() {
   $form['uclalib_bookplates_spak_url'] = array(
     '#type' => 'textfield',
     '#title' => t('Spak URL'),
-    '#default_value' => variable_get('uclalib_bookplates_spak_url', 'http://catalog.library.ucla.edu/vwebv/search?searchArg1='),
+    '#default_value' => variable_get('uclalib_bookplates_spak_url', 'http://catalog.library.ucla.edu/vwebv/search?searchArg=SPAE+'),
     '#size' => 100,
     '#maxlength' => 1000,
     '#description' => t("The spak code URL"),
@@ -94,7 +94,7 @@ function uclalib_bookplates_admin() {
   $form['uclalib_bookplates_spak_args'] = array(
     '#type' => 'textfield',
     '#title' => t('Spak args'),
-    '#default_value' => variable_get('uclalib_bookplates_spak_args', '&argType1=all&searchCode1=SPAK&combine2=and&searchArg2=&argType2=all&searchCode2=SPAK&combine3=and&searchArg3=&argType3=all&searchCode3=GKEY&year=2014-2015&fromYear=&toYear=&location=all&place=all&type=all&status=all&medium=all&language=all&content=all&media=all&carrier=all&recCount=50&searchType=2&page.search.search.button=Search'),
+    '#default_value' => variable_get('uclalib_bookplates_spak_args', '&searchCode=CMD&setLimit=1&recCount=50&searchType=1&page.search.search.button=Search'),
     '#size' => 100,
     '#maxlength' => 1000,
     '#description' => t("The spak code arguments to be passed"),
@@ -227,4 +227,13 @@ function uclalib_bookplates_update_7200(&$sandbox) {
     field_delete_field($field);
     field_purge_batch();
   }
+}
+
+/**
+ * Updates variables for Catalog linking per DRUP-1142.
+ */
+function uclalib_bookplates_update_7201(&$sandbox) {
+  // Same variables as in uclalib_bookplates_admin()
+  variable_set('uclalib_bookplates_spak_url', 'http://catalog.library.ucla.edu/vwebv/search?searchArg=SPAE+');
+  variable_set('uclalib_bookplates_spak_args', '&searchCode=CMD&setLimit=1&recCount=50&searchType=1&page.search.search.button=Search');
 }


### PR DESCRIPTION
@z3cka Please review and merge/deploy to www-test.

Note that I had to add a hook_update_N function, thus requiring database update.  I tried just changing the variable default values in uclalib_bookplates_admin but apparently those only apply when using the admin form itself, and we need the values to be set automatically.  Unfortunately this results in these 2 variable values being hard-coded in two places, which seems quite wrong... feel free to revise or to point me in the correct direction.

I bumped the version from beta1 to beta2 in the info file, hope I remembered that correctly.

Thanks --Andy