### PR TITLE
DRUP-1124: #awaiting adds text to social links

### DIFF
--- a/www/sites/all/modules/features/uclalib_system/plugins/content_types/meta_social.inc
+++ b/www/sites/all/modules/features/uclalib_system/plugins/content_types/meta_social.inc
@@ -31,33 +31,28 @@ $plugin = array(
 function meta_social_content_type_render($subtype, $conf, $args, $context) {
   $share_this_text = NULL;
   $block = new stdClass();
-  $block->content = '';
+
+  $block->content['#attached']['css'][] = array(
+    'type' => 'external',
+    'data' => 'https://cdn.rawgit.com/FortAwesome/Font-Awesome/v4.7.0/css/font-awesome.min.css',
+  );
+  $block->content['#attached']['css'][] = array(
+    'type' => 'external',
+    'data' => 'https://cdn.rawgit.com/tabalinas/jssocials/v1.4.0/dist/jssocials.css',
+  );
+  $block->content['#attached']['css'][] = array(
+    'type' => 'external',
+    'data' => 'https://cdn.rawgit.com/tabalinas/jssocials/v1.4.0/dist/jssocials-theme-flat.css',
+  );
+
+  $block->content['#attached']['js'][] = array(
+    'type' => 'external',
+    'data' => 'https://cdn.rawgit.com/tabalinas/jssocials/v1.4.0/dist/jssocials.min.js',
+  );
+
+  $block->content['#theme'] = 'uclalib_system_meta_social';
 
   $block->title = '';
-
-  $block->content .= <<<EOL
-<div class="addthis-block">
-<span class="addthis-text">$share_this_text</span>
-  <span class="addthis_toolbox addthis_default_style addthis_32x32_style">
-    <a class="addthis_button_facebook"></a>
-    <a class="addthis_button_twitter"></a>
-    <a class="addthis_button_email"></a>
-  </span>
-</div>
-<script type="text/javascript" src="https://s7.addthis.com/js/250/addthis_widget.js#pubid=ra-531762c77afe51ca"></script>
-<style type="text/css">
-.addthis-block {
-  min-height: 32px;
-}
-.addthis_32x32_style a span {
-  -webkit-border-radius: 50%;
-  -moz-border-radius: 50%;
-  -ms-border-radius: 50%;
-  -o-border-radius: 50%;
-  border-radius: 50%;
-}
-</style>
-EOL;
 
   return $block;
 }

--- a/www/sites/all/modules/features/uclalib_system/plugins/content_types/templates/uclalib-system-meta-social.tpl.php
+++ b/www/sites/all/modules/features/uclalib_system/plugins/content_types/templates/uclalib-system-meta-social.tpl.php
@@ -1,0 +1,17 @@
+<div id="share"></div>
+
+<script>
+  (function ($) {
+    $("#share").jsSocials({
+      showLabel: true,
+      shares: [
+        "twitter", "facebook", { share: "email", logo: "fa fa-envelope-o" }
+      ]
+    });
+  }(jQuery));
+</script>
+
+<style type="text/css">
+  .jssocials-share-link { border-radius: 50%; }
+  .jssocials-share-label { display: none; }
+</style>

--- a/www/sites/all/modules/features/uclalib_system/uclalib_system.info
+++ b/www/sites/all/modules/features/uclalib_system/uclalib_system.info
@@ -1,7 +1,7 @@
 name = UCLA Library System
 description = System wide configuration for the UCLA Library site.
 core = 7.x
-version = 7.x-1.1
+version = 7.x-1.2
 package = UCLALIB
 dependencies[] = ctools
 dependencies[] = features

--- a/www/sites/all/modules/features/uclalib_system/uclalib_system.module
+++ b/www/sites/all/modules/features/uclalib_system/uclalib_system.module
@@ -58,6 +58,18 @@ function uclalib_system_required_modules() {
 }
 
 /**
+ * Implements hook_theme().
+ */
+function uclalib_system_theme($existing, $type, $theme, $path) {
+  return array(
+    'uclalib_system_meta_social' => array(
+      'render element' => 'block',
+      'template' => 'plugins/content_types/templates/uclalib-system-meta-social',
+    ),
+  );
+}
+
+/**
  * Implements hook_flush_caches().
  */
 function uclalib_system_flush_caches() {


### PR DESCRIPTION
* DRUP-1124: #ready adds text to social links

This was done by switching to a more robust library

commit 2c542926e76081a94117eba8d64b733397b2c08c
Author: Casey Grzecka <cgrzecka@library.ucla.edu>
Date:   Thu Jan 19 07:06:39 2017 +0000

    DRUP-1124: changes order of share icons, email icon to envelope, and minor secletor change and jQuery syntax

commit de11198e009ace4abedebae7a496d07bc94e0752
Author: Casey Grzecka <cgrzecka@library.ucla.edu>
Date:   Thu Jan 19 06:19:18 2017 +0000

    DRUP-1124: moves template to template file and loads external js/css via attached property

commit 0883a8ce7c7bf9ebd4abed528bf8d5ca05a949fb
Author: Casey Grzecka <cgrzecka@library.ucla.edu>
Date:   Wed Jan 18 19:52:52 2017 +0000

    DRUP-1124: WIP on using jssocials to replace addthis TODO: remove nasty inline template

* dropping beta