### PR TITLE
DRUP-1262: #ready fixes the data-label for location hours tables

### DIFF
--- a/www/sites/all/modules/custom/ucla_libhours/ucla-libhours-hours.tpl.php
+++ b/www/sites/all/modules/custom/ucla_libhours/ucla-libhours-hours.tpl.php
@@ -65,7 +65,7 @@
           </td>
           <% _.each(location.weeks[week_index], function(day) { %>
             <% if (day.date) { %>
-              <td data-label="<%= dateFormat(day.date, "ddd d") %>" <% if (day.date == dateFormat("yyyy-mm-dd")) { %>' class="current-day"'<% } %>><%= day.rendered %></td>
+              <td data-label="<%= dateFormat(day.date, "ddd d", true) %>" <% if (day.date == dateFormat("yyyy-mm-dd")) { %>' class="current-day"'<% } %>><%= day.rendered %></td>
             <% } %>
           <% }); %>
         </tr>  


### PR DESCRIPTION
This was due to javascript rendering the user's day on the date provided adjusted for their timezone. The desired day of the week is that actual day of that date. This was achieved by forcing javascript to use UTC for the timezone by passing true as the third parameter to the dateFormat() function. This is documented here: http://blog.stevenlevithan.com/archives/date-time-format

_Oh the joys of javascript!_