### PR TITLE
DRUP-1297: Use left-anchored ISBL index for ISBN searches in Catalog

### DIFF
--- a/www/sites/all/modules/custom/ucla_tab_search/ucla_tab_search.info
+++ b/www/sites/all/modules/custom/ucla_tab_search/ucla_tab_search.info
@@ -1,5 +1,5 @@
 name = UCLA Tab Search
 description = Custom tab forms for searching on the UCLA Library homepage.
 core = 7.x
-version = "7.x-1.7-beta2"
+version = "7.x-1.8"
 dependencies[] = ucla_search

--- a/www/sites/all/modules/custom/ucla_tab_search/ucla_tab_search.module
+++ b/www/sites/all/modules/custom/ucla_tab_search/ucla_tab_search.module
@@ -95,7 +95,7 @@ function ucla_tab_search_tabs_form($form, &$form_state) {
         'SUBJ@' => t('Subject list'),
         'SUBJ+' => t('Subject list - start of'),
         'CALL+' => t('Call number'),
-        'ISBN' => t('ISBN'),
+        'ISBL' => t('ISBN'),
         'ISSN' => t('ISSN'),
     ),
     '#states' => array(


### PR DESCRIPTION
@z3cka Here's a minor change to bring the website's homepage search module into sync with Catalog changes done on VBT-1002.

I bumped the module version up to 1.8, hope that's OK.

Please deploy to test when you get a chance.  I'll do a quick test, and then this can go to production whenever.  Nothing's broken for this in prod now... this just fixes a long-standing problem.

Thanks --Andy