### PR TITLE
DRUP-1084: views more links

### DIFF
--- a/www/sites/all/modules/features/uclalib_news/uclalib_news.views_default.inc
+++ b/www/sites/all/modules/features/uclalib_news/uclalib_news.views_default.inc
@@ -726,7 +726,7 @@ function uclalib_news_views_default_views() {
   $handler->display->display_options['fields']['name']['relationship'] = 'field_news_categories_tid';
   $handler->display->display_options['fields']['name']['label'] = '';
   $handler->display->display_options['fields']['name']['alter']['alter_text'] = TRUE;
-  $handler->display->display_options['fields']['name']['alter']['text'] = '<a href="/news?f[0]=field_news_categories%3A[tid]">[name]</a>';
+  $handler->display->display_options['fields']['name']['alter']['text'] = '<a href="/news?f[0]=field_news_categories&#37;3A[tid]">[name]</a>';
   $handler->display->display_options['fields']['name']['element_label_colon'] = FALSE;
   /* Sort criterion: Content: Post date */
   $handler->display->display_options['sorts']['created']['id'] = 'created';

--- a/www/sites/all/modules/features/uclalib_quick_find/uclalib_quick_find.views_default.inc
+++ b/www/sites/all/modules/features/uclalib_quick_find/uclalib_quick_find.views_default.inc
@@ -83,7 +83,7 @@ function uclalib_quick_find_views_default_views() {
   $handler->display->display_options['fields']['name']['relationship'] = 'field_quick_find_terms_target_id';
   $handler->display->display_options['fields']['name']['label'] = '';
   $handler->display->display_options['fields']['name']['alter']['alter_text'] = TRUE;
-  $handler->display->display_options['fields']['name']['alter']['text'] = '<a href="/locations?f[0]=field_equipment%3A[tid]">[name]</a>';
+  $handler->display->display_options['fields']['name']['alter']['text'] = '<a href="/locations?f[0]=field_equipment&#37;3A[tid]">[name]</a>';
   $handler->display->display_options['fields']['name']['element_label_colon'] = FALSE;
   /* Contextual filter: Block: Internal, numeric block ID */
   $handler->display->display_options['arguments']['bid']['id'] = 'bid';

--- a/www/sites/all/modules/features/uclalib_resources/uclalib_resources.pages_default.inc
+++ b/www/sites/all/modules/features/uclalib_resources/uclalib_resources.pages_default.inc
@@ -480,7 +480,7 @@ function uclalib_resources_default_page_manager_pages() {
     $pane->configuration = array(
       'admin_title' => 'Find Resources Horizontal Tab Navigation',
       'title' => '',
-      'body' => '<p>Get help with your research | <a href="/locations?f[0]=field_study_areas%3A34">Find a quiet Study Area</a> | <a href="/locations?f[0]=field_study_areas%3A36">Find a Group Study Area</a></p>
+      'body' => '<p>Get help with your research | <a href="/locations?f[0]=field_study_areas&#37;3A34">Find a quiet Study Area</a> | <a href="/locations?f[0]=field_study_areas&#37;3A36">Find a Group Study Area</a></p>
 ',
       'format' => 'full_html',
       'substitute' => TRUE,

--- a/www/sites/all/modules/features/uclalib_resources/uclalib_resources.views_default.inc
+++ b/www/sites/all/modules/features/uclalib_resources/uclalib_resources.views_default.inc
@@ -242,7 +242,7 @@ if (count($node->field_resource_associated_loc[LANGUAGE_NONE])) {
   $handler->display->display_options['fields']['name']['field'] = 'name';
   $handler->display->display_options['fields']['name']['label'] = '';
   $handler->display->display_options['fields']['name']['alter']['alter_text'] = TRUE;
-  $handler->display->display_options['fields']['name']['alter']['text'] = '<a class="resource-term-search-link" href="/search-research/find-resources?f[0]=field_resource_type%3A[tid]">[name]</a>';
+  $handler->display->display_options['fields']['name']['alter']['text'] = '<a class="resource-term-search-link" href="/search-research/find-resources?f[0]=field_resource_type&#37;3A[tid]">[name]</a>';
   $handler->display->display_options['fields']['name']['alter']['word_boundary'] = FALSE;
   $handler->display->display_options['fields']['name']['alter']['ellipsis'] = FALSE;
   $handler->display->display_options['fields']['name']['element_label_colon'] = FALSE;

--- a/www/sites/all/modules/features/uclalib_upcoming_events/uclalib_upcoming_events.features.field_base.inc
+++ b/www/sites/all/modules/features/uclalib_upcoming_events/uclalib_upcoming_events.features.field_base.inc
@@ -10,21 +10,13 @@
 function uclalib_upcoming_events_field_default_field_bases() {
   $field_bases = array();
 
-  // Exported field_base: 'field_upcoming_events_events'
+  // Exported field_base: 'field_upcoming_events_events'.
   $field_bases['field_upcoming_events_events'] = array(
     'active' => 1,
     'cardinality' => -1,
     'deleted' => 0,
     'entity_types' => array(),
     'field_name' => 'field_upcoming_events_events',
-    'foreign keys' => array(
-      'node' => array(
-        'columns' => array(
-          'target_id' => 'nid',
-        ),
-        'table' => 'node',
-      ),
-    ),
     'indexes' => array(
       'target_id' => array(
         0 => 'target_id',

--- a/www/sites/all/modules/features/uclalib_upcoming_events/uclalib_upcoming_events.features.field_instance.inc
+++ b/www/sites/all/modules/features/uclalib_upcoming_events/uclalib_upcoming_events.features.field_instance.inc
@@ -10,7 +10,8 @@
 function uclalib_upcoming_events_field_default_field_instances() {
   $field_instances = array();
 
-  // Exported field_instance: 'bean-upcoming_events-field_upcoming_events_events'
+  // Exported field_instance:
+  // 'bean-upcoming_events-field_upcoming_events_events'.
   $field_instances['bean-upcoming_events-field_upcoming_events_events'] = array(
     'bundle' => 'upcoming_events',
     'default_value' => NULL,

--- a/www/sites/all/modules/features/uclalib_upcoming_events/uclalib_upcoming_events.info
+++ b/www/sites/all/modules/features/uclalib_upcoming_events/uclalib_upcoming_events.info
@@ -30,5 +30,4 @@ features[views_view][] = recent_news_highlight
 features[views_view][] = upcoming_events_display
 features[views_view][] = upcoming_events_reference
 features[views_view][] = upcoming_news_reference
-mtime = 1476466458
 project path = sites/all/modules/features

--- a/www/sites/all/modules/features/uclalib_upcoming_events/uclalib_upcoming_events.module
+++ b/www/sites/all/modules/features/uclalib_upcoming_events/uclalib_upcoming_events.module
@@ -240,8 +240,9 @@ function uclalib_upcoming_events_preprocess_views_view(&$variables) {
     $options = [];
     $i = 0;
 
-    // Arg 0 is id from field_news_categories, so let's skip this one so
-    // unless Arg 1 is empty.
+    // Arg 0 is a term id for field_news_categories, so for a simplified more
+    // link that casts a wider net, do not add this filter this unless
+    // Location is empty.
     if ((empty($view->args[1]) || $view->args[1] == 'all') && !empty($view->args[0])) {
       foreach (explode('+', $view->args[0]) as $id) {
         if ($id != 'all') {
@@ -250,13 +251,21 @@ function uclalib_upcoming_events_preprocess_views_view(&$variables) {
       }
     }
 
-    // Arg 1 is id from field_news_location
+    // Arg 1 is a node id for field_news_location, it should be added to the
+    // view's more link when it is non-empty and not set to 'all'.
     if (!empty($view->args[1])) {
       foreach (explode('+', $view->args[1]) as $id) {
         if ($id != 'all') {
           $options['query']['f[' . $i++ . ']'] = "field_news_location:{$id}";
         }
       }
+    }
+
+    // Arg 2 is an id or ids for Subject Area, however the subject area is not
+    // exposed facet filter on /news search page, therefore we're obliged to
+    // ignore it in the more link.
+    if (!empty($view->args[2])) {
+      // do nothing.
     }
 
     $theme = views_theme_functions('views_more', $view, $view->display[$display_id]);

--- a/www/sites/all/modules/features/uclalib_upcoming_events/uclalib_upcoming_events.module
+++ b/www/sites/all/modules/features/uclalib_upcoming_events/uclalib_upcoming_events.module
@@ -225,3 +225,42 @@ function uclalib_upcoming_events_cron() {
     }
   }
 }
+
+/**
+ * Prepares variables for views-view.tpl.php
+ */
+function uclalib_upcoming_events_preprocess_views_view(&$variables) {
+  $view = $variables['view'];
+
+  // Build a custom more link to the pre-filtered news page by integrating
+  // the news location field from views context.
+  if ($view->name == 'recent_news_highlight' && in_array($view->current_display, array('panel_pane_1', 'panel_pane_2'))) {
+
+    $options = [];
+    $i = 0;
+
+    // Arg 0 is id from field_news_categories, so let's skip this one so
+    // unless Arg 1 is empty.
+    if ((empty($view->args[1]) || $view->args[1] == 'all') && !empty($view->args[0])) {
+      foreach (explode('+', $view->args[0]) as $id) {
+        if ($id != 'all') {
+          $options['query']['f[' . $i++ . ']'] = "field_news_categories:{$id}";
+        }
+      }
+    }
+
+    // Arg 1 is id from field_news_location
+    if (!empty($view->args[1])) {
+      foreach (explode('+', $view->args[1]) as $id) {
+        if ($id != 'all') {
+          $options['query']['f[' . $i++ . ']'] = "field_news_location:{$id}";
+        }
+      }
+    }
+
+    $theme = views_theme_functions('views_more', $view, $view->current_display);
+    $path = check_url(url('news', $options));
+
+    $variables['more'] = theme($theme, array('more_url' => $path, 'new_window' => FALSE, 'link_text' => t('More'), 'view' => $view));
+  }
+}

--- a/www/sites/all/modules/features/uclalib_upcoming_events/uclalib_upcoming_events.module
+++ b/www/sites/all/modules/features/uclalib_upcoming_events/uclalib_upcoming_events.module
@@ -231,6 +231,7 @@ function uclalib_upcoming_events_cron() {
  */
 function uclalib_upcoming_events_preprocess_views_view(&$variables) {
   $view = $variables['view'];
+  $display_id = $variables['display_id'];
 
   // Build a custom more link to the pre-filtered news page by integrating
   // the news location field from views context.
@@ -258,7 +259,7 @@ function uclalib_upcoming_events_preprocess_views_view(&$variables) {
       }
     }
 
-    $theme = views_theme_functions('views_more', $view, $view->current_display);
+    $theme = views_theme_functions('views_more', $view, $view->display[$display_id]);
     $path = check_url(url('news', $options));
 
     $variables['more'] = theme($theme, array('more_url' => $path, 'new_window' => FALSE, 'link_text' => t('More'), 'view' => $view));

--- a/www/sites/all/modules/features/uclalib_upcoming_events/uclalib_upcoming_events.views_default.inc
+++ b/www/sites/all/modules/features/uclalib_upcoming_events/uclalib_upcoming_events.views_default.inc
@@ -37,13 +37,6 @@ function uclalib_upcoming_events_views_default_views() {
   $handler->display->display_options['style_options']['default_row_class'] = FALSE;
   $handler->display->display_options['style_options']['row_class_special'] = FALSE;
   $handler->display->display_options['row_plugin'] = 'fields';
-  /* Footer: Global: Unfiltered text */
-  $handler->display->display_options['footer']['area_text_custom']['id'] = 'area_text_custom';
-  $handler->display->display_options['footer']['area_text_custom']['table'] = 'views';
-  $handler->display->display_options['footer']['area_text_custom']['field'] = 'area_text_custom';
-  $handler->display->display_options['footer']['area_text_custom']['empty'] = TRUE;
-  $handler->display->display_options['footer']['area_text_custom']['content'] = '<div class="more-link"> <a href="/news?f[0]=field_news_categories&#37;3A!1&f[1]=field_news_location&#37;3A!2">More</a></div>';
-  $handler->display->display_options['footer']['area_text_custom']['tokenize'] = TRUE;
   /* Field: Content: Nid */
   $handler->display->display_options['fields']['nid']['id'] = 'nid';
   $handler->display->display_options['fields']['nid']['table'] = 'node';
@@ -162,13 +155,6 @@ function uclalib_upcoming_events_views_default_views() {
   /* Display: Recent News with Images */
   $handler = $view->new_display('panel_pane', 'Recent News with Images', 'panel_pane_1');
   $handler->display->display_options['defaults']['footer'] = FALSE;
-  /* Footer: Global: Unfiltered text */
-  $handler->display->display_options['footer']['area_text_custom']['id'] = 'area_text_custom';
-  $handler->display->display_options['footer']['area_text_custom']['table'] = 'views';
-  $handler->display->display_options['footer']['area_text_custom']['field'] = 'area_text_custom';
-  $handler->display->display_options['footer']['area_text_custom']['empty'] = TRUE;
-  $handler->display->display_options['footer']['area_text_custom']['content'] = '<div class="more-link"> <a href="news?f[0]=field_news_categories&#37;3A!1&#38;f[1]=field_news_location&#37;3A!2">More</a></div>';
-  $handler->display->display_options['footer']['area_text_custom']['tokenize'] = TRUE;
   $handler->display->display_options['defaults']['fields'] = FALSE;
   /* Field: Content: Nid */
   $handler->display->display_options['fields']['nid']['id'] = 'nid';

--- a/www/sites/all/modules/features/uclalib_upcoming_events/uclalib_upcoming_events.views_default.inc
+++ b/www/sites/all/modules/features/uclalib_upcoming_events/uclalib_upcoming_events.views_default.inc
@@ -42,7 +42,7 @@ function uclalib_upcoming_events_views_default_views() {
   $handler->display->display_options['footer']['area_text_custom']['table'] = 'views';
   $handler->display->display_options['footer']['area_text_custom']['field'] = 'area_text_custom';
   $handler->display->display_options['footer']['area_text_custom']['empty'] = TRUE;
-  $handler->display->display_options['footer']['area_text_custom']['content'] = '<div class="more-link"> <a href="/news?f[0]=field_news_categories%3A!1&f[1]=field_news_location%3A!2">More</a></div>';
+  $handler->display->display_options['footer']['area_text_custom']['content'] = '<div class="more-link"> <a href="/news?f[0]=field_news_categories&#37;3A!1&f[1]=field_news_location&#37;3A!2">More</a></div>';
   $handler->display->display_options['footer']['area_text_custom']['tokenize'] = TRUE;
   /* Field: Content: Nid */
   $handler->display->display_options['fields']['nid']['id'] = 'nid';
@@ -167,7 +167,7 @@ function uclalib_upcoming_events_views_default_views() {
   $handler->display->display_options['footer']['area_text_custom']['table'] = 'views';
   $handler->display->display_options['footer']['area_text_custom']['field'] = 'area_text_custom';
   $handler->display->display_options['footer']['area_text_custom']['empty'] = TRUE;
-  $handler->display->display_options['footer']['area_text_custom']['content'] = '<div class="more-link"> <a href="news?f[0]=field_news_categories&#37;3[A]!1&#38;f[1]=field_news_location&#37;3A!2">More</a></div>';
+  $handler->display->display_options['footer']['area_text_custom']['content'] = '<div class="more-link"> <a href="news?f[0]=field_news_categories&#37;3A!1&#38;f[1]=field_news_location&#37;3A!2">More</a></div>';
   $handler->display->display_options['footer']['area_text_custom']['tokenize'] = TRUE;
   $handler->display->display_options['defaults']['fields'] = FALSE;
   /* Field: Content: Nid */

--- a/www/sites/all/themes/uclalib_omega/css/uclalib-omega.no-query.css
+++ b/www/sites/all/themes/uclalib_omega/css/uclalib-omega.no-query.css
@@ -4443,10 +4443,10 @@ span#expandAll.links.links, span#collapseAll.links.links.links {
 .pane-bean-upcoming-events h2 + .pane-content {
   padding: 6px;
 }
-.ui-tabs .ui-tabs-panel .view-recent-news-highlight .view-footer,
-.ui-tabs .ui-tabs-panel .view-upcoming-events-display .view-footer,
-.pane-bean-upcoming-events h2 + .pane-content .view-recent-news-highlight .view-footer,
-.pane-bean-upcoming-events h2 + .pane-content .view-upcoming-events-display .view-footer {
+.ui-tabs .ui-tabs-panel .view-recent-news-highlight .more-link,
+.ui-tabs .ui-tabs-panel .view-upcoming-events-display .more-link,
+.pane-bean-upcoming-events h2 + .pane-content .view-recent-news-highlight .more-link,
+.pane-bean-upcoming-events h2 + .pane-content .view-upcoming-events-display .more-link {
   padding-right: 14px;
   text-align: right;
 }

--- a/www/sites/all/themes/uclalib_omega/css/uclalib-omega.no-query.css
+++ b/www/sites/all/themes/uclalib_omega/css/uclalib-omega.no-query.css
@@ -1415,7 +1415,7 @@ td.grid-3:nth-last-child(-n+3) {
 .page-contact .pane-staff-search-pane p {
   margin-top: 5px;
 }
-.page-contact .pane-contact-location-list .more-link, .page-contact .pane-contact-location-list .more-link-block a, .more-link-block .page-contact .pane-contact-location-list a {
+.page-contact .pane-contact-location-list .more-link {
   margin-bottom: 1.5em;
   text-align: left;
 }
@@ -1648,7 +1648,7 @@ td.grid-3:nth-last-child(-n+3) {
   margin-top: 8px;
 }
 
-.pane-exhibitions-highlight-exhibition-highlight-pane .more-link, .pane-exhibitions-highlight-exhibition-highlight-pane .more-link-block a, .more-link-block .pane-exhibitions-highlight-exhibition-highlight-pane a {
+.pane-exhibitions-highlight-exhibition-highlight-pane .more-link {
   text-align: left;
   margin-top: 10px;
 }
@@ -2186,7 +2186,7 @@ a.more-link,
     display: none;
   }
 }
-.bean-news-and-events-bean .view-header .more-link, .bean-news-and-events-bean .view-header .more-link-block a, .more-link-block .bean-news-and-events-bean .view-header a {
+.bean-news-and-events-bean .view-header .more-link {
   margin: -66px 11px 0 0;
 }
 @media (min-width: 481px) {
@@ -2194,7 +2194,7 @@ a.more-link,
     display: none;
   }
 }
-.bean-news-and-events-bean .view-footer .more-link, .bean-news-and-events-bean .view-footer .more-link-block a, .more-link-block .bean-news-and-events-bean .view-footer a {
+.bean-news-and-events-bean .view-footer .more-link {
   text-align: left;
   padding: 0 11px 15px;
 }
@@ -2219,7 +2219,7 @@ a.more-link,
 .bean-news-and-events-bean .is-mobile .view-header {
   float: none;
 }
-.bean-news-and-events-bean .is-mobile .view-header .more-link, .bean-news-and-events-bean .is-mobile .view-header .more-link-block a, .more-link-block .bean-news-and-events-bean .is-mobile .view-header a {
+.bean-news-and-events-bean .is-mobile .view-header .more-link {
   margin: 0;
   text-align: left;
 }

--- a/www/sites/all/themes/uclalib_omega/css/uclalib-omega.styles.css
+++ b/www/sites/all/themes/uclalib_omega/css/uclalib-omega.styles.css
@@ -4443,10 +4443,10 @@ span#expandAll.links.links, span#collapseAll.links.links.links {
 .pane-bean-upcoming-events h2 + .pane-content {
   padding: 6px;
 }
-.ui-tabs .ui-tabs-panel .view-recent-news-highlight .view-footer,
-.ui-tabs .ui-tabs-panel .view-upcoming-events-display .view-footer,
-.pane-bean-upcoming-events h2 + .pane-content .view-recent-news-highlight .view-footer,
-.pane-bean-upcoming-events h2 + .pane-content .view-upcoming-events-display .view-footer {
+.ui-tabs .ui-tabs-panel .view-recent-news-highlight .more-link,
+.ui-tabs .ui-tabs-panel .view-upcoming-events-display .more-link,
+.pane-bean-upcoming-events h2 + .pane-content .view-recent-news-highlight .more-link,
+.pane-bean-upcoming-events h2 + .pane-content .view-upcoming-events-display .more-link {
   padding-right: 14px;
   text-align: right;
 }

--- a/www/sites/all/themes/uclalib_omega/css/uclalib-omega.styles.css
+++ b/www/sites/all/themes/uclalib_omega/css/uclalib-omega.styles.css
@@ -1415,7 +1415,7 @@ td.grid-3:nth-last-child(-n+3) {
 .page-contact .pane-staff-search-pane p {
   margin-top: 5px;
 }
-.page-contact .pane-contact-location-list .more-link, .page-contact .pane-contact-location-list .more-link-block a, .more-link-block .page-contact .pane-contact-location-list a {
+.page-contact .pane-contact-location-list .more-link {
   margin-bottom: 1.5em;
   text-align: left;
 }
@@ -1648,7 +1648,7 @@ td.grid-3:nth-last-child(-n+3) {
   margin-top: 8px;
 }
 
-.pane-exhibitions-highlight-exhibition-highlight-pane .more-link, .pane-exhibitions-highlight-exhibition-highlight-pane .more-link-block a, .more-link-block .pane-exhibitions-highlight-exhibition-highlight-pane a {
+.pane-exhibitions-highlight-exhibition-highlight-pane .more-link {
   text-align: left;
   margin-top: 10px;
 }
@@ -2186,7 +2186,7 @@ a.more-link,
     display: none;
   }
 }
-.bean-news-and-events-bean .view-header .more-link, .bean-news-and-events-bean .view-header .more-link-block a, .more-link-block .bean-news-and-events-bean .view-header a {
+.bean-news-and-events-bean .view-header .more-link {
   margin: -66px 11px 0 0;
 }
 @media (min-width: 481px) {
@@ -2194,7 +2194,7 @@ a.more-link,
     display: none;
   }
 }
-.bean-news-and-events-bean .view-footer .more-link, .bean-news-and-events-bean .view-footer .more-link-block a, .more-link-block .bean-news-and-events-bean .view-footer a {
+.bean-news-and-events-bean .view-footer .more-link {
   text-align: left;
   padding: 0 11px 15px;
 }
@@ -2219,7 +2219,7 @@ a.more-link,
 .bean-news-and-events-bean .is-mobile .view-header {
   float: none;
 }
-.bean-news-and-events-bean .is-mobile .view-header .more-link, .bean-news-and-events-bean .is-mobile .view-header .more-link-block a, .more-link-block .bean-news-and-events-bean .is-mobile .view-header a {
+.bean-news-and-events-bean .is-mobile .view-header .more-link {
   margin: 0;
   text-align: left;
 }

--- a/www/sites/all/themes/uclalib_omega/package-lock.json
+++ b/www/sites/all/themes/uclalib_omega/package-lock.json
@@ -1,0 +1,596 @@
+{
+  "name": "uclalib_omega",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "abbrev": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+      "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
+      "dev": true
+    },
+    "amdefine": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+      "integrity": "sha1-/RdHRwDLXMnCtwnwvp0jzjwZjDM=",
+      "dev": true
+    },
+    "argparse": {
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+      "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
+      "dev": true,
+      "requires": {
+        "underscore": "1.7.0",
+        "underscore.string": "2.4.0"
+      },
+      "dependencies": {
+        "underscore.string": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+          "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=",
+          "dev": true
+        }
+      }
+    },
+    "async": {
+      "version": "0.1.22",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
+      "integrity": "sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE=",
+      "dev": true
+    },
+    "camelcase": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+      "dev": true
+    },
+    "cli": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/cli/-/cli-0.4.3.tgz",
+      "integrity": "sha1-5oGcjV+qlX9k+Y9mqFBiaMHR8X0=",
+      "dev": true,
+      "requires": {
+        "glob": "3.1.21"
+      }
+    },
+    "coffee-script": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
+      "integrity": "sha1-FQ1rTLUiiUNp7+1qIQHCC8f0pPQ=",
+      "dev": true
+    },
+    "colors": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+      "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
+      "dev": true
+    },
+    "dateformat": {
+      "version": "1.0.2-1.2.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
+      "integrity": "sha1-sCIMAt6YYXQztyhRz0fePfLNvuk=",
+      "dev": true
+    },
+    "debug": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+      "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
+      "dev": true
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
+    "esprima": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+      "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=",
+      "dev": true
+    },
+    "eventemitter2": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+      "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
+      "dev": true
+    },
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true
+    },
+    "faye-websocket": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.4.tgz",
+      "integrity": "sha1-wUxbO/FNdBf/v9mQwKdJXNnzN7w=",
+      "dev": true
+    },
+    "fileset": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.1.8.tgz",
+      "integrity": "sha1-UGuRqTluqn4y+0KoQHfHoMc2t0E=",
+      "dev": true,
+      "requires": {
+        "glob": "3.1.21",
+        "minimatch": "0.2.14"
+      }
+    },
+    "findup-sync": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+      "integrity": "sha1-fz56l7gjksZTvwZYm9hRkOk8NoM=",
+      "dev": true,
+      "requires": {
+        "glob": "3.2.11",
+        "lodash": "2.4.2"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "3.2.11",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+          "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.1",
+            "minimatch": "0.3.0"
+          }
+        },
+        "lodash": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+          "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "2.7.3",
+            "sigmund": "1.0.1"
+          }
+        }
+      }
+    },
+    "gaze": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.3.4.tgz",
+      "integrity": "sha1-X5S92gr+U7xxCWm81vKCVI1gwnk=",
+      "dev": true,
+      "requires": {
+        "fileset": "0.1.8",
+        "minimatch": "0.2.14"
+      }
+    },
+    "getobject": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
+      "integrity": "sha1-BHpEl4n6Fg0Bj1SG7ZEyC27HiFw=",
+      "dev": true
+    },
+    "glob": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+      "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "1.2.3",
+        "inherits": "1.0.2",
+        "minimatch": "0.2.14"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+          "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
+          "dev": true
+        }
+      }
+    },
+    "graceful-fs": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+      "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
+      "dev": true
+    },
+    "grunt": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
+      "integrity": "sha1-VpN81RlDJK3/bSB2MYMqnWuk5/A=",
+      "dev": true,
+      "requires": {
+        "async": "0.1.22",
+        "coffee-script": "1.3.3",
+        "colors": "0.6.2",
+        "dateformat": "1.0.2-1.2.3",
+        "eventemitter2": "0.4.14",
+        "exit": "0.1.2",
+        "findup-sync": "0.1.3",
+        "getobject": "0.1.0",
+        "glob": "3.1.21",
+        "grunt-legacy-log": "0.1.3",
+        "grunt-legacy-util": "0.2.0",
+        "hooker": "0.2.3",
+        "iconv-lite": "0.2.11",
+        "js-yaml": "2.0.5",
+        "lodash": "0.9.2",
+        "minimatch": "0.2.14",
+        "nopt": "1.0.10",
+        "rimraf": "2.2.8",
+        "underscore.string": "2.2.1",
+        "which": "1.0.9"
+      }
+    },
+    "grunt-contrib-compass": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-compass/-/grunt-contrib-compass-0.2.0.tgz",
+      "integrity": "sha1-F2QloIQpOLaLkqwAceayJnWbChQ=",
+      "dev": true,
+      "requires": {
+        "grunt-lib-contrib": "0.5.3",
+        "tmp": "0.0.16"
+      }
+    },
+    "grunt-contrib-jshint": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-0.1.1.tgz",
+      "integrity": "sha1-qeJYFB5rL0Z8V39Wctl+xk7yWD0=",
+      "dev": true,
+      "requires": {
+        "jshint": "0.9.1"
+      }
+    },
+    "grunt-contrib-uglify": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-uglify/-/grunt-contrib-uglify-0.2.7.tgz",
+      "integrity": "sha1-5r2lHgxAoUWfbOrUI8Ze/XJaG/c=",
+      "dev": true,
+      "requires": {
+        "grunt-lib-contrib": "0.6.1",
+        "uglify-js": "2.4.24"
+      },
+      "dependencies": {
+        "grunt-lib-contrib": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/grunt-lib-contrib/-/grunt-lib-contrib-0.6.1.tgz",
+          "integrity": "sha1-P1att9oG6BR5XuJBWw6+X7iQPrs=",
+          "dev": true,
+          "requires": {
+            "zlib-browserify": "0.0.1"
+          }
+        }
+      }
+    },
+    "grunt-contrib-watch": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-watch/-/grunt-contrib-watch-0.4.4.tgz",
+      "integrity": "sha1-Mg/HfFzTO3PlRGzZ7ZGWEhFqpjw=",
+      "dev": true,
+      "requires": {
+        "gaze": "0.3.4",
+        "tiny-lr": "0.0.4"
+      }
+    },
+    "grunt-legacy-log": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
+      "integrity": "sha1-7ClCboAwIa9ZAp+H0vnNczWgVTE=",
+      "dev": true,
+      "requires": {
+        "colors": "0.6.2",
+        "grunt-legacy-log-utils": "0.1.1",
+        "hooker": "0.2.3",
+        "lodash": "2.4.2",
+        "underscore.string": "2.3.3"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+          "dev": true
+        },
+        "underscore.string": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+          "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
+          "dev": true
+        }
+      }
+    },
+    "grunt-legacy-log-utils": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
+      "integrity": "sha1-wHBrndkGThFvNvI/5OawSGcsD34=",
+      "dev": true,
+      "requires": {
+        "colors": "0.6.2",
+        "lodash": "2.4.2",
+        "underscore.string": "2.3.3"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+          "dev": true
+        },
+        "underscore.string": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+          "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
+          "dev": true
+        }
+      }
+    },
+    "grunt-legacy-util": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
+      "integrity": "sha1-kzJIhNv343qf98Am3/RR2UqeVUs=",
+      "dev": true,
+      "requires": {
+        "async": "0.1.22",
+        "exit": "0.1.2",
+        "getobject": "0.1.0",
+        "hooker": "0.2.3",
+        "lodash": "0.9.2",
+        "underscore.string": "2.2.1",
+        "which": "1.0.9"
+      }
+    },
+    "grunt-lib-contrib": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/grunt-lib-contrib/-/grunt-lib-contrib-0.5.3.tgz",
+      "integrity": "sha1-6D+e5cigZZLW6CWCHZEhB4IIEzg=",
+      "dev": true,
+      "requires": {
+        "zlib-browserify": "0.0.1"
+      }
+    },
+    "grunt-shell": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/grunt-shell/-/grunt-shell-0.3.1.tgz",
+      "integrity": "sha1-PLkjzLlq9dPkmAiZhRpDIc/32O4=",
+      "dev": true,
+      "requires": {
+        "stripcolorcodes": "0.1.0"
+      }
+    },
+    "hooker": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+      "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk=",
+      "dev": true
+    },
+    "iconv-lite": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
+      "integrity": "sha1-HOYKOleGSiktEyH/RgnKS7llrcg=",
+      "dev": true
+    },
+    "inherits": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
+      "integrity": "sha1-olrmUJmZ6X3yeMZxnaEb0Gh3Q6g=",
+      "dev": true,
+      "requires": {
+        "argparse": "0.1.16",
+        "esprima": "1.0.4"
+      }
+    },
+    "jshint": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/jshint/-/jshint-0.9.1.tgz",
+      "integrity": "sha1-/zLsfwn4QAH3SY7q/WPJ5Puy3A4=",
+      "dev": true,
+      "requires": {
+        "cli": "0.4.3",
+        "minimatch": "0.0.5"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-1.0.6.tgz",
+          "integrity": "sha1-qlD5cEdCKsclQ72hd6nJ0BjZhFI=",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.0.5.tgz",
+          "integrity": "sha1-lrtJC707poNrv6wRGt91MBsVhN4=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "1.0.6"
+          }
+        }
+      }
+    },
+    "lodash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
+      "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=",
+      "dev": true
+    },
+    "lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+      "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "2.7.3",
+        "sigmund": "1.0.1"
+      }
+    },
+    "nopt": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+      "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1.0.9"
+      }
+    },
+    "noptify": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/noptify/-/noptify-0.0.3.tgz",
+      "integrity": "sha1-WPZUpz2XU98MUdlobckhBKZ/S7s=",
+      "dev": true,
+      "requires": {
+        "nopt": "2.0.0"
+      },
+      "dependencies": {
+        "nopt": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.0.0.tgz",
+          "integrity": "sha1-ynQW8gpeP5w7hhgPlilfo9C1Lg0=",
+          "dev": true,
+          "requires": {
+            "abbrev": "1.0.9"
+          }
+        }
+      }
+    },
+    "qs": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz",
+      "integrity": "sha1-MbGtBYVnZRxSaSFQa5qHk5EaA4Q=",
+      "dev": true
+    },
+    "rimraf": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+      "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
+      "dev": true
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+      "dev": true
+    },
+    "source-map": {
+      "version": "0.1.34",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
+      "integrity": "sha1-p8/omux7FoLDsZjQrPtH19CQVms=",
+      "dev": true,
+      "requires": {
+        "amdefine": "1.0.0"
+      }
+    },
+    "stripcolorcodes": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/stripcolorcodes/-/stripcolorcodes-0.1.0.tgz",
+      "integrity": "sha1-Hkuhuf74zC8PcFvaK9mds7ylXIA=",
+      "dev": true
+    },
+    "tiny-lr": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-0.0.4.tgz",
+      "integrity": "sha1-gGGFR/Y/aX0Fy0DEwsSwg1Ia77Y=",
+      "dev": true,
+      "requires": {
+        "debug": "0.7.4",
+        "faye-websocket": "0.4.4",
+        "noptify": "0.0.3",
+        "qs": "0.5.6"
+      }
+    },
+    "tmp": {
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.16.tgz",
+      "integrity": "sha1-cE6gUTwVN1OJ71tt3oZXMFKPIkU=",
+      "dev": true
+    },
+    "uglify-js": {
+      "version": "2.4.24",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
+      "integrity": "sha1-+tV1XB4Vd2WLsG/5q25UjJW+vW4=",
+      "dev": true,
+      "requires": {
+        "async": "0.2.10",
+        "source-map": "0.1.34",
+        "uglify-to-browserify": "1.0.2",
+        "yargs": "3.5.4"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+          "dev": true
+        }
+      }
+    },
+    "uglify-to-browserify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+      "dev": true
+    },
+    "underscore": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+      "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
+      "dev": true
+    },
+    "underscore.string": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
+      "integrity": "sha1-18D6KvXVoaZ/QlPa7pgTLnM/Dxk=",
+      "dev": true
+    },
+    "which": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
+      "integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8=",
+      "dev": true
+    },
+    "window-size": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+      "dev": true
+    },
+    "wordwrap": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+      "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+      "dev": true
+    },
+    "yargs": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
+      "integrity": "sha1-2K/49mXpTDS9JZvevRv68N3TU2E=",
+      "dev": true,
+      "requires": {
+        "camelcase": "1.2.1",
+        "decamelize": "1.2.0",
+        "window-size": "0.1.0",
+        "wordwrap": "0.0.2"
+      }
+    },
+    "zlib-browserify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/zlib-browserify/-/zlib-browserify-0.0.1.tgz",
+      "integrity": "sha1-T6akXQDbwV8xikr6HZr8Aljhdsw=",
+      "dev": true
+    }
+  }
+}

--- a/www/sites/all/themes/uclalib_omega/sass/components/_more-link.scss
+++ b/www/sites/all/themes/uclalib_omega/sass/components/_more-link.scss
@@ -28,7 +28,8 @@
 }
 
 div.more-link > a,
-a.more-link {
+a.more-link,
+%more-link {
   color: $ucla-blue;
   @extend .more-link-triangle-after;
 }
@@ -40,6 +41,6 @@ a.more-link {
   padding: 20px;
   text-align: center;
   a {
-    @extend .more-link;
+    @extend %more-link;
   }
 }

--- a/www/sites/all/themes/uclalib_omega/sass/components/_upcoming-events.scss
+++ b/www/sites/all/themes/uclalib_omega/sass/components/_upcoming-events.scss
@@ -40,7 +40,7 @@
   padding: 6px;
   .view-recent-news-highlight,
   .view-upcoming-events-display {
-    .view-footer {
+    .more-link {
       padding-right: 14px;
       text-align: right;
     }


### PR DESCRIPTION
This PR fixes the broken "more" links on the News tab on Destinations and Locations:

Steps to review:

1) Visit a Location page, Eg. https://drup-1084-views-more-42glrty-sopc3ixpdigl4.us-2.platformsh.site/sel
2) Scroll down to the News block and click "More"
3) Ensure you're redirected to the /news page with the correct pre-filtered Location in the sidebar facets.


1) Visit a Destination page Eg https://drup-1084-views-more-42glrty-sopc3ixpdigl4.us-2.platformsh.site/destination/research-commons
2) Scroll down to the News block and click "More"
3) Ensure you're redirected to the /news page with the correct pre-filtered Location based on the destination in the sidebar facets.


Other things that were changed in this feature:

* The solution moves the more link out of the footer, from the views configuration screen, into a custom code solution in a preprocess function.
* This change caused a small issue with the theme's sass styles pulling in too many styles due to a poorly coded sass `@extends`, so I've refactored it to use a sass `%more-link` placeholder, instead of a normal classname. 
* The theme was also missing a `package-lock.json` file which was introduced a few years ago in npm version 5 (version 6 is out now).  This file lets us ensure everyone has the same npm package dependencies installed on their local machines.
