### PR TITLE
DRUP-1314: Staff Search sort by relevance, then first letter of last name

### DIFF
--- a/www/sites/all/modules/features/uclalib_staff_directory/uclalib_staff_directory.views_default.inc
+++ b/www/sites/all/modules/features/uclalib_staff_directory/uclalib_staff_directory.views_default.inc
@@ -889,6 +889,15 @@ function uclalib_staff_directory_views_default_views() {
     'image_style' => '',
     'image_link' => '',
   );
+  /* Sort criterion: Search: Relevance */
+  $handler->display->display_options['sorts']['search_api_relevance']['id'] = 'search_api_relevance';
+  $handler->display->display_options['sorts']['search_api_relevance']['table'] = 'search_api_index_site_general_search';
+  $handler->display->display_options['sorts']['search_api_relevance']['field'] = 'search_api_relevance';
+  $handler->display->display_options['sorts']['search_api_relevance']['order'] = 'DESC';
+  /* Sort criterion: Indexed Content: Staff Alpha */
+  $handler->display->display_options['sorts']['field_staff_glossary_index']['id'] = 'field_staff_glossary_index';
+  $handler->display->display_options['sorts']['field_staff_glossary_index']['table'] = 'search_api_index_site_general_search';
+  $handler->display->display_options['sorts']['field_staff_glossary_index']['field'] = 'field_staff_glossary_index';
   /* Filter criterion: Indexed Content: Content type */
   $handler->display->display_options['filters']['type']['id'] = 'type';
   $handler->display->display_options['filters']['type']['table'] = 'search_api_index_site_general_search';


### PR DESCRIPTION
An imperfect solution that gets us close to the desired effect sorting results by relevance then by first letter of last name.  Adding a more thorough solution whereby the alpha sort takes into account the fullname by "first, last" would be a non-trivial additional effort, with a new custom field, and a full solr reindex.

Environment link: 
https://drup-1314-staff-search-luhvimy-sopc3ixpdigl4.us-2.platformsh.site/staff?search_api_views_fulltext=charles